### PR TITLE
increased fluentd daemonset tolerations

### DIFF
--- a/katalog/fluentd/deploy.yml
+++ b/katalog/fluentd/deploy.yml
@@ -15,8 +15,7 @@ spec:
     spec:
       serviceAccountName: fluentd
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - operator: Exists
       containers:
       - name: fluentd
         image: sighup/fluentd-elasticsearch:1.2.8


### PR DESCRIPTION
The set of tolerations of fluentd daemonset is too restricted, in this way it'll tolerate any taint applied to nodes and won't need "special" Kustomize patches to get correctly scheduled.