### PR TITLE
Remove tolerations to fluentd sts, avoid to run on master

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,17 @@
+# Logging Core Module version 1.Y.Z
+
+Since we changed the logging architecture (v1.4.0), we forgot to remove toleration in the fluentd
+StatefulSet. This setting allows fluentd to run on master nodes.
+
+## Changelog
+
+- Remove fluentd StatefulSet tolerations.
+
+## Upgrade path
+
+To upgrade this core module from `v1.6.0` to `v1.Y.Z`, you need to download this new version, then apply the
+`kustomize` projects. No further action is required.
+
+```bash
+kustomize build katalog/fluentd | kubectl apply -f -
+```

--- a/katalog/fluentd/fluentd.yml
+++ b/katalog/fluentd/fluentd.yml
@@ -30,8 +30,6 @@ spec:
                       - fluentd
               topologyKey: kubernetes.io/hostname
       serviceAccountName: fluentd
-      tolerations:
-      - operator: Exists
       containers:
       - name: fluentd
         image: quay.io/sighup/fluentd-elasticsearch


### PR DESCRIPTION
Spotted by the delivery team, fluentd can run in master nodes. Witch, it is not intended.

With this simple PR we fix that behavior!
As remediation (suggested by @nutellinoit) create a patch with some tolerations like:

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: fluentd
  namespace: logging
spec:
  template:
    spec:
      nodeSelector:
        node-role.kubernetes.io/infra: ""
      tolerations:
      - key: node-role.kubernetes.io/infra
        operator: Exists
        effect: NoSchedule
```

Thanks!