### PR TITLE
Changing update strategy to Recreate and changing cpu limits to 2 cores

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,5 @@
+# Logging Core Module version 1.Y.Z
+
+## Changelog
+
+- Changed Kibana rolling strategy to Recreate and removing kibana cpu limits

--- a/katalog/kibana/kibana.yml
+++ b/katalog/kibana/kibana.yml
@@ -24,6 +24,8 @@ metadata:
   labels:
     app: kibana
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -77,7 +79,7 @@ spec:
               cpu: 100m
               memory: 500Mi
             limits:
-              cpu: 300m
+              cpu: "2"
               memory: 800Mi
           volumeMounts:
             - name: config-volume


### PR DESCRIPTION
Hi team! 

Another little PR, changing kibana strategy due to some indexes migration problems (.kibana being stuck, etc) and changing cpu limits to 2, because when kibana starts, there is a lot of Javascript compling and some heavy cpu stuff, causing .kibana indexes to not migrate or being stuck in a broken state