### PR TITLE
fix issue on fluentd parsing with ingress controller log when some fi…

### DIFF
--- a/katalog/fluentd/conf.d/ingress-controller-output.conf
+++ b/katalog/fluentd/conf.d/ingress-controller-output.conf
@@ -1,6 +1,6 @@
 <filter kubernetes.var.log.containers.nginx-ingress-**.log>
   @type parser
-  format /^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+) (?<upstream_response_time>[\d.]+) (?<upstream_status>\d+) (?<req_id>[^ ]*)/
+  format /^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+|-) (?<upstream_response_time>[\d.]+|-) (?<upstream_status>\d+|-) (?<req_id>[^ ]*)/
   time_format %d/%b/%Y:%H:%M:%S %z
   key_name log
   types status:integer,body_bytes_sent:integer,request_length:integer,upstream_response_length:integer,upstream_response_time:float,upstream_status:integer


### PR DESCRIPTION
Hi everyone 👋 ,
today I faced an issue when there are HTTP request (such as HEAD, or call that doesn't have load time such as 301). Basically the parser in those cases breaks and simply the log is not indexed (present, but with no index recognized). With this fallback (the `-`) the log is indexed and you have the interesting fields (such as status and all the other fields there).
Let me know if you see some possible regressions :) 