### PR TITLE
added capability to create index-pattern from configuration file

### DIFF
--- a/katalog/kibana/config/index-patterns.ndjson
+++ b/katalog/kibana/config/index-patterns.ndjson
@@ -1,0 +1,3 @@
+{"type":"index-pattern","id":"system","attributes":{"title":"system-*","timeFieldName":"@timestamp"}}
+{"type":"index-pattern","id":"kubernetes","attributes":{"title":"kubernetes-*","timeFieldName":"@timestamp"}}
+{"type":"index-pattern","id":"ingress-controller","attributes":{"title":"ingress-controller-*","timeFieldName":"@timestamp"}}

--- a/katalog/kibana/kibana.yml
+++ b/katalog/kibana/kibana.yml
@@ -13,7 +13,7 @@ spec:
   ports:
     - port: 5601
       name: http
-      protocol: TCP 
+      protocol: TCP
   selector:
     app: kibana
 ---
@@ -25,8 +25,8 @@ metadata:
     app: kibana
 spec:
   replicas: 1
-  selector: 
-    matchLabels: 
+  selector:
+    matchLabels:
       app: kibana
   template:
     metadata:
@@ -36,45 +36,57 @@ spec:
       securityContext:
         fsGroup: 1000
       containers:
-      - name: kibana
-        image: docker.elastic.co/kibana/kibana
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsNonRoot: true
-          runAsUser: 1000
-        readinessProbe:
-          exec:
-            command:
-              - sh
-              - -c
-              - |
-                #!/usr/bin/env bash -e
-                http () {
-                    local path="${1}"
-                    set -- -XGET -s --fail -L
-                    if [ -n "${ELASTICSEARCH_USERNAME}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
-                      set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
-                    fi
-                    STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "http://localhost:5601${path}")
-                    if [[ "${STATUS}" -eq 200 ]]; then
-                      exit 0
-                    fi
-                    echo "Error: Got HTTP code ${STATUS} but expected a 200"
-                    exit 1
-                }
-                http /app/kibana
-        ports:
-          - containerPort: 5601
-            name: http
-        env:
-        - name: ELASTICSEARCH_URL
-          value: "http://elasticsearch:9200"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 500Mi
-          limits: 
-            cpu: 300m
-            memory: 800Mi
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  #!/usr/bin/env bash -e
+                  http () {
+                      local path="${1}"
+                      set -- -XGET -s --fail -L
+                      if [ -n "${ELASTICSEARCH_USERNAME}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
+                        set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
+                      fi
+                      STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "http://localhost:5601${path}")
+                      if [[ "${STATUS}" -eq 200 ]]; then
+                          curl -X POST "localhost:5601/api/saved_objects/_import?overwrite=true" -H "kbn-xsrf: true" --form file=@file.ndjson
+                        exit 0
+                      fi
+                      echo "Error: Got HTTP code ${STATUS} but expected a 200"
+                      exit 1
+                  }
+                  http /app/kibana
+          ports:
+            - containerPort: 5601
+              name: http
+          env:
+            - name: ELASTICSEARCH_URL
+              value: "http://elasticsearch:9200"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 500Mi
+            limits:
+              cpu: 300m
+              memory: 800Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /usr/share/kibana/file.ndjson
+              subPath: file.ndjson
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kibana-index-patterns-configmap
+            items:
+              - key: file.ndjson
+                path: file.ndjson

--- a/katalog/kibana/kustomization.yaml
+++ b/katalog/kibana/kustomization.yaml
@@ -15,3 +15,9 @@ images:
 
 resources:
   - kibana.yml
+
+configMapGenerator:
+  - name: kibana-index-patterns-configmap
+    namespace: logging
+    files:
+      - file.ndjson=config/index-patterns.ndjson


### PR DESCRIPTION
Hi @everyone 👋 !
This PR wants to introduce the creation of kibana index-patterns directly from a configuration file. The reason of putting the HTTP post in the readinessProbe is because the service must be up and running and kibana takes minutes to do that, so there isn't other good alternative( probably one alternative could be a job, but the job should check the readiness of the kibana service, so could be an overengineering of the current implementation).
Well, if you have good alternative, please write down 👇  any further suggestions!