### PR TITLE
Differentiate templates for each stream, suppress ES 7 warn on fluentd

### DIFF
--- a/katalog/fluentd/conf.d/audit-output.conf
+++ b/katalog/fluentd/conf.d/audit-output.conf
@@ -25,10 +25,10 @@
    logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME_AUDIT'] || 'audit'}"
-   type_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TYPE_NAME'] || '_doc'}"
+   suppress_type_name true
    include_timestamp "#{ENV['FLUENT_ELASTICSEARCH_INCLUDE_TIMESTAMP'] || 'false'}"
-   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"
-   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE'] || use_nil}"
+   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME_AUDIT'] || use_nil}"
+   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_AUDIT'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
    request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"

--- a/katalog/fluentd/conf.d/ingress-controller-output.conf
+++ b/katalog/fluentd/conf.d/ingress-controller-output.conf
@@ -35,11 +35,11 @@
      logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
      logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
      index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME_INGRESS'] || 'ingress-controller'}"
-     type_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TYPE_NAME'] || '_doc'}"
+     suppress_type_name true
      include_timestamp "#{ENV['FLUENT_ELASTICSEARCH_INCLUDE_TIMESTAMP'] || 'false'}"
      utc_index 'true'
-     template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"
-     template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE'] || use_nil}"
+     template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME_INGRESS_CONTROLLER'] || use_nil}"
+     template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_INGRESS_CONTROLLER'] || use_nil}"
      template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
      sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
      request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"

--- a/katalog/fluentd/conf.d/kubernetes-output.conf
+++ b/katalog/fluentd/conf.d/kubernetes-output.conf
@@ -25,10 +25,10 @@
    logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME_KUBERNETES'] || 'kubernetes'}"
-   type_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TYPE_NAME'] || '_doc'}"
+   suppress_type_name true
    include_timestamp "#{ENV['FLUENT_ELASTICSEARCH_INCLUDE_TIMESTAMP'] || 'false'}"
-   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"
-   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE'] || use_nil}"
+   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME_KUBERNETES'] || use_nil}"
+   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_KUBERNETES'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
    request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"

--- a/katalog/fluentd/conf.d/system-output.conf
+++ b/katalog/fluentd/conf.d/system-output.conf
@@ -25,10 +25,10 @@
    logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME_SYSTEM'] || 'system'}"
-   type_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TYPE_NAME'] || '_doc'}"
+   suppress_type_name true
    include_timestamp "#{ENV['FLUENT_ELASTICSEARCH_INCLUDE_TIMESTAMP'] || 'false'}"
-   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"
-   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE'] || use_nil}"
+   template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME_SYSTEM'] || use_nil}"
+   template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_SYSTEM'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
    request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"

--- a/katalog/fluentd/fluentd-index-sighup-template-audit.json
+++ b/katalog/fluentd/fluentd-index-sighup-template-audit.json
@@ -1,0 +1,8 @@
+{
+  "index_patterns" : ["audit-*"],
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "codec": "best_compression"
+  }
+}

--- a/katalog/fluentd/fluentd-index-sighup-template-ingress-controller.json
+++ b/katalog/fluentd/fluentd-index-sighup-template-ingress-controller.json
@@ -1,0 +1,8 @@
+{
+  "index_patterns" : ["ingress-controller-*"],
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "codec": "best_compression"
+  }
+}

--- a/katalog/fluentd/fluentd-index-sighup-template-kubernetes.json
+++ b/katalog/fluentd/fluentd-index-sighup-template-kubernetes.json
@@ -1,0 +1,8 @@
+{
+  "index_patterns" : ["kubernetes-*"],
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "codec": "best_compression"
+  }
+}

--- a/katalog/fluentd/fluentd-index-sighup-template-system.json
+++ b/katalog/fluentd/fluentd-index-sighup-template-system.json
@@ -1,5 +1,5 @@
 {
-  "index_patterns" : ["system-*","kubernetes-*","ingress-controller-*","audit-*"],
+  "index_patterns" : ["system-*"],
   "settings": {
     "number_of_shards": 1,
     "number_of_replicas": 1,

--- a/katalog/fluentd/fluentd.yml
+++ b/katalog/fluentd/fluentd.yml
@@ -42,10 +42,22 @@ spec:
             value: "9200"
           - name: FLUENT_ELASTICSEARCH_SCHEME
             value: "http"
-          - name: FLUENT_ELASTICSEARCH_TEMPLATE_NAME
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_NAME_KUBERNETES
             value: "fluentd-index-sighup"
-          - name: FLUENT_ELASTICSEARCH_TEMPLATE_FILE
-            value: "/etc/tmp-conf/index-template/fluentd-index-sighup-template.json"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_FILE_KUBERNETES
+            value: "/etc/tmp-conf/index-template/fluentd-index-sighup-template-kubernetes.json"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_NAME_AUDIT
+            value: "fluentd-index-sighup-audit"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_FILE_AUDIT
+            value: "/etc/tmp-conf/index-template/fluentd-index-sighup-template-audit.json"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_NAME_INGRESS_CONTROLLER
+            value: "fluentd-index-sighup-ingress-controller"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_FILE_INGRESS_CONTROLLER
+            value: "/etc/tmp-conf/index-template/fluentd-index-sighup-template-ingress-controller.json"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_NAME_SYSTEM
+            value: "fluentd-index-sighup-system"
+          - name: FLUENT_ELASTICSEARCH_TEMPLATE_FILE_SYSTEM
+            value: "/etc/tmp-conf/index-template/fluentd-index-sighup-template-system.json"
           - name: FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE
             value: "true"
         ports:

--- a/katalog/fluentd/kustomization.yaml
+++ b/katalog/fluentd/kustomization.yaml
@@ -34,7 +34,10 @@ configMapGenerator:
     - audit-output.conf=conf.d/audit-output.conf
 - name: fluentd-index-template
   files:
-    - fluentd-index-sighup-template.json
+    - fluentd-index-sighup-template-kubernetes.json
+    - fluentd-index-sighup-template-audit.json
+    - fluentd-index-sighup-template-system.json
+    - fluentd-index-sighup-template-ingress-controller.json
 - name: fluentbit-dedot-script
   files:
     - dedot.lua=scripts/dedot.lua


### PR DESCRIPTION
Hi team, little PR to enhance the template management, one file for each index stream and a little param change to suppress the `_doc` field when sending logs on ES.

Right now fluentd is emitting warn on stdout:

```txt
fluentd-0 fluentd warning: 299 Elasticsearch-7.10.1-1c34507e66d7db1211f66f3513706fdf548736aa "[types removal] Specifying types in bulk requests is deprecated."
```