### PR TITLE
Moved readiness probe as startup probe. Reverted readiness probe to check only Kibana status

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,3 +3,4 @@
 ## Changelog
 
 - Changed Kibana rolling strategy to Recreate and removing kibana cpu limits
+- Added startupProbe that creates index-patterns, reverted readinessProbe to the previous version

--- a/katalog/kibana/kibana.yml
+++ b/katalog/kibana/kibana.yml
@@ -46,7 +46,7 @@ spec:
                 - ALL
             runAsNonRoot: true
             runAsUser: 1000
-          readinessProbe:
+          startupProbe:
             exec:
               command:
                 - sh
@@ -62,6 +62,27 @@ spec:
                       STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "http://localhost:5601${path}")
                       if [[ "${STATUS}" -eq 200 ]]; then
                           curl -X POST "localhost:5601/api/saved_objects/_import?overwrite=true" -H "kbn-xsrf: true" --form file=@file.ndjson
+                        exit 0
+                      fi
+                      echo "Error: Got HTTP code ${STATUS} but expected a 200"
+                      exit 1
+                  }
+                  http /app/kibana
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  #!/usr/bin/env bash -e
+                  http () {
+                      local path="${1}"
+                      set -- -XGET -s --fail -L
+                      if [ -n "${ELASTICSEARCH_USERNAME}" ] && [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
+                        set -- "$@" -u "${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
+                      fi
+                      STATUS=$(curl --output /dev/null --write-out "%{http_code}" -k "$@" "http://localhost:5601${path}")
+                      if [[ "${STATUS}" -eq 200 ]]; then
                         exit 0
                       fi
                       echo "Error: Got HTTP code ${STATUS} but expected a 200"


### PR DESCRIPTION
Hi team, we found that the new readinessProbe creates some flapping on kibana pod, usually when someone is using Kibana.

I changed the probe that installs index patterns as a startupProbe and replaced the readinessProbe with the old one.

startupProbe is beta from 1.18, and graduated to GA in 1.20