### PR TITLE
Update config that prevents fluentd from capturing own logs

### DIFF
--- a/katalog/fluentd/fluent.conf
+++ b/katalog/fluentd/fluent.conf
@@ -30,6 +30,9 @@
   @type prometheus_output_monitor
 </source>
 
-<match fluent.**>
-  @type null
-</match>
+# do not collect fluentd own logs (avoid infinite loops).
+<label @FLUENT_LOG>
+  <match fluent.**>
+    @type null
+  </match>
+</label>


### PR DESCRIPTION
warn message fixed:
define <match fluent.**> to capture fluentd logs in top level is deprecated.
Use <label @FLUENT_LOG> instead.

Relevant documentation:
https://docs.fluentd.org/deployment/logging#capture-fluentd-logs