### PR TITLE
Use @label routing

### DIFF
--- a/katalog/fluentd/fluent.conf
+++ b/katalog/fluentd/fluent.conf
@@ -1,5 +1,3 @@
-@include conf.d/*.conf
-
 <system>
     log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
     suppress_repeated_stacktrace true
@@ -8,6 +6,7 @@
 
 <source>
     @type forward
+    @label @ES
     @id main_forward
     bind "0.0.0.0"
     port 24240
@@ -29,6 +28,20 @@
 <source>
   @type prometheus_output_monitor
 </source>
+
+<label @ES>
+@include conf.d/audit-output.conf
+@include conf.d/ingress-controller-output.conf
+@include conf.d/kubernetes-output.conf
+@include conf.d/system-output.conf
+</label>
+
+<label @ERROR>
+  <match **>
+    @type "file"
+    path "/buffers/errors/fluentd.*.errors"
+  </match>
+</label>
 
 <match fluent.**>
   @type null


### PR DESCRIPTION
Use @label routing (@ES and @ERROR) to send
malformed logs to the /buffers/errors thus
avoiding the situation where buffers get filled
with malformed logs causing the logging stack
to stop working.

ref:
https://github.com/uken/fluent-plugin-elasticsearch/blob/master/README.Troubleshooting.md#using-label-feature