### PR TITLE
Change default logging level from error to warn

### DIFF
--- a/katalog/fluentd/conf.d/audit-output.conf
+++ b/katalog/fluentd/conf.d/audit-output.conf
@@ -5,7 +5,7 @@
 <match audit.**>
    @type elasticsearch
    @id out_es_audit
-   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
+   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
    id_key _hash # specify same key name which is specified in hash_id_key
    remove_keys _hash # Elasticsearch doesn't like keys that start with _
    include_tag_key true

--- a/katalog/fluentd/conf.d/audit-output.conf
+++ b/katalog/fluentd/conf.d/audit-output.conf
@@ -34,7 +34,7 @@
    request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"
    <buffer>
      @type "file"
-     path "/buffers/fluentd.autid.*.buffer"
+     path "/buffers/fluentd.audit.*.buffer"
      flush_thread_count "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
      flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '10s'}"
      chunk_limit_size "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"

--- a/katalog/fluentd/conf.d/ingress-controller-output.conf
+++ b/katalog/fluentd/conf.d/ingress-controller-output.conf
@@ -15,7 +15,7 @@
   <store>
      @type elasticsearch
      @id out_es_ingress
-     @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
+     @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
      id_key _hash # specify same key name which is specified in hash_id_key
      remove_keys _hash # Elasticsearch doesn't like keys that start with _
      include_tag_key true

--- a/katalog/fluentd/conf.d/kubernetes-output.conf
+++ b/katalog/fluentd/conf.d/kubernetes-output.conf
@@ -5,7 +5,7 @@
 <match kubernetes.**>
    @type elasticsearch
    @id out_es_kubernetes
-   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
+   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
    id_key _hash # specify same key name which is specified in hash_id_key
    remove_keys _hash # Elasticsearch doesn't like keys that start with _
    include_tag_key true

--- a/katalog/fluentd/conf.d/system-output.conf
+++ b/katalog/fluentd/conf.d/system-output.conf
@@ -5,7 +5,7 @@
 <match system.**>
    @type elasticsearch
    @id out_es_system
-   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
+   @log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
    id_key _hash # specify same key name which is specified in hash_id_key
    remove_keys _hash # Elasticsearch doesn't like keys that start with _
    include_tag_key true

--- a/katalog/fluentd/fluent.conf
+++ b/katalog/fluentd/fluent.conf
@@ -1,7 +1,7 @@
 @include conf.d/*.conf
 
 <system>
-    log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'error'}"
+    log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
     suppress_repeated_stacktrace true
     log_event_verbose false
 </system>


### PR DESCRIPTION
Use warning log level as error level was hiding
fluentd logs that were highlighting log rejecionts
by ElasticSearch.

Set both at the global and at the plugin level

ref:
https://docs.fluentd.org/deployment/logging#per-plugin-log