### PR TITLE
Prepare for release v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ your Kubernetes cluster.
   graphical user interface. Version: **0.8.5**
 - [curator](katalog/curator): Curator instance to manage Elasticsearch indices. Version: **5.8.1**
 - [elasticsearch-single](katalog/elasticsearch-single): Single node Elasticsearch
-  deployment. Version: **6.8.8**
+  deployment. Version: **6.8.12**
 - [elasticsearch-triple](katalog/elasticsearch-triple): Three node Elasticsearch cluster
-  deployment. Version: **6.8.8**
+  deployment. Version: **6.8.12**
 - [fluentd](katalog/fluentd): fluentd instance to collect logging data and store in
   Elasticsearch. Version: **1.10.2**
-- [kibana](katalog/kibana): Kibana instance to visualize and analyse Elasticsearch data. Version: **6.8.8**
+- [kibana](katalog/kibana): Kibana instance to visualize and analyse Elasticsearch data. Version: **6.8.21**
 
 You can click on each package to see its documentation.
 

--- a/katalog/elasticsearch-single/README.md
+++ b/katalog/elasticsearch-single/README.md
@@ -13,7 +13,7 @@ Kubernetes.
 
 ## Image repository and tag
 
-* Elasticsearch image: `docker.elastic.co/elasticsearch/elasticsearch:6.8.8`
+* Elasticsearch image: `docker.elastic.co/elasticsearch/elasticsearch:6.8.21`
 * Elasticsearch repo: https://github.com/elastic/elasticsearch
 * Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/index.html
 

--- a/katalog/elasticsearch-single/kustomization.yaml
+++ b/katalog/elasticsearch-single/kustomization.yaml
@@ -4,7 +4,7 @@ images:
   - name: justwatch/elasticsearch_exporter
     newTag: "1.1.0"
   - name: docker.elastic.co/elasticsearch/elasticsearch
-    newTag: "6.8.8"
+    newTag: "6.8.21"
 
 resources:
   - elasticsearch.yml

--- a/katalog/elasticsearch-triple/README.md
+++ b/katalog/elasticsearch-triple/README.md
@@ -13,7 +13,7 @@ Kubernetes.
 
 ## Image repository and tag
 
-* Elasticsearch image: `docker.elastic.co/elasticsearch/elasticsearch:6.8.8`
+* Elasticsearch image: `docker.elastic.co/elasticsearch/elasticsearch:6.8.21`
 * Elasticsearch repo: https://github.com/elastic/elasticsearch
 * Elasticsearch documentation:  https://www.elastic.co/guide/en/elasticsearch/reference/6.4/index.html
 

--- a/katalog/kibana/README.md
+++ b/katalog/kibana/README.md
@@ -12,7 +12,7 @@ stored in Elasticsearch indices.
 
 ## Image repository and tag
 
-* Kibana image: `docker.elastic.co/kibana/kibana:6.8.8`
+* Kibana image: `docker.elastic.co/kibana/kibana:6.8.21`
 * Kibana repo: https://github.com/elastic/kibana
 * Kibana documentation: https://www.elastic.co/guide/en/kibana/6.8/index.html
 

--- a/katalog/kibana/kustomization.yaml
+++ b/katalog/kibana/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: logging
 
 images:
   - name: docker.elastic.co/kibana/kibana
-    newTag: 6.8.8
+    newTag: 6.8.21
 
 resources:
   - kibana.yml


### PR DESCRIPTION
This patch adds the es and kibana versions that fixes `CVE-2021–44228`.