### PR TITLE
Increase request_timeout from 5 to 60 seconds

### DIFF
--- a/katalog/fluentd/conf.d/audit-output.conf
+++ b/katalog/fluentd/conf.d/audit-output.conf
@@ -31,7 +31,7 @@
    template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_AUDIT'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
-   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"
+   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '60s'}"
    <buffer>
      @type "file"
      path "/buffers/fluentd.audit.*.buffer"

--- a/katalog/fluentd/conf.d/ingress-controller-output.conf
+++ b/katalog/fluentd/conf.d/ingress-controller-output.conf
@@ -42,7 +42,7 @@
      template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_INGRESS_CONTROLLER'] || use_nil}"
      template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
      sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
-     request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"
+     request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '60s'}"
      <buffer>
        @type "file"
        path "/buffers/fluentd.ingress-controller.*.buffer"

--- a/katalog/fluentd/conf.d/kubernetes-output.conf
+++ b/katalog/fluentd/conf.d/kubernetes-output.conf
@@ -31,7 +31,7 @@
    template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_KUBERNETES'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
-   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"
+   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '60s'}"
    <buffer>
      @type "file"
      path "/buffers/fluentd.kubernetes.*.buffer"

--- a/katalog/fluentd/conf.d/system-output.conf
+++ b/katalog/fluentd/conf.d/system-output.conf
@@ -31,7 +31,7 @@
    template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE_SYSTEM'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
    sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
-   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '5s'}"
+   request_timeout "#{ENV['FLUENT_ELASTICSEARCH_REQUEST_TIMEOUT'] || '60s'}"
    <buffer>
      @type "file"
      path "/buffers/fluentd.system.*.buffer"


### PR DESCRIPTION
5 seconds is too low of a number for the following reasons:

1. fluentd makes bulk requests: if the bulk request is big (more than 2MB) it can go in timeout. The effect of the timeout is to retry the bulk request, which will fail again because is too big.

2. On some customers we had to increase the chunk_limit_size to more than 2MB to avoid losing logs bigger than 2MB and we fell in the problem explained in point number 1

3. If the logging funnel stop working down the line (i.e. fluentbit stop sending logs for whatever reason) and then restarts to work after sometime, a flood of log could reach fluentd which will make a lot of bulk request with the size of the chunk_limit_size and the request_timeout could exacerbate the problem

When bulk_requests take more than 20 seconds a warning is logged in fluentd, so we can monitor the health of the logging funnel.