### PR TITLE
update (index-pattern): add index pattern for events

### DIFF
--- a/katalog/kibana/config/index-patterns.ndjson
+++ b/katalog/kibana/config/index-patterns.ndjson
@@ -1,3 +1,4 @@
 {"type":"index-pattern","id":"systemd","attributes":{"title":"systemd-*","timeFieldName":"@timestamp"}}
 {"type":"index-pattern","id":"kubernetes","attributes":{"title":"kubernetes-*","timeFieldName":"@timestamp"}}
 {"type":"index-pattern","id":"ingress-controller","attributes":{"title":"ingress-controller-*","timeFieldName":"@timestamp"}}
+{"type":"index-pattern","id":"events","attributes":{"title":"events-*","timeFieldName":"@timestamp"}}


### PR DESCRIPTION
this will enable Kibana to have the events index already loaded in by default.