### PR TITLE
fix (kibana): disable unused plugin and add event indexpattern

### DIFF
--- a/katalog/kibana/config/index-patterns.ndjson
+++ b/katalog/kibana/config/index-patterns.ndjson
@@ -1,3 +1,4 @@
 {"type":"index-pattern","id":"systemd","attributes":{"title":"systemd-*","timeFieldName":"@timestamp"}}
 {"type":"index-pattern","id":"kubernetes","attributes":{"title":"kubernetes-*","timeFieldName":"@timestamp"}}
 {"type":"index-pattern","id":"ingress-controller","attributes":{"title":"ingress-controller-*","timeFieldName":"@timestamp"}}
+{"type":"index-pattern","id":"events","attributes":{"title":"events-*","timeFieldName":"@timestamp"}}

--- a/katalog/kibana/kibana.yml
+++ b/katalog/kibana/kibana.yml
@@ -74,12 +74,12 @@ spec:
             - name: ELASTICSEARCH_URL
               value: "http://elasticsearch:9200"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=800"
+              value: "--max-old-space-size=400"
             - name: MONITORING_UI_ENABLED
               value: "false"
             - name: APM_ENABLED
               value: "false"
-            - name: TIMELION_ENABLED
+            - name: TIMELION_ENABLE
               value: "false"
             - name: MAPS_ENABLED
               value: "false"
@@ -96,10 +96,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 1024Mi
+              memory: 500Mi
             limits:
               cpu: "2"
-              memory: 1024Mi
+              memory: 500Mi
         - name: kibana-index-patterns
           image: docker.elastic.co/kibana/kibana
           securityContext:

--- a/katalog/kibana/kibana.yml
+++ b/katalog/kibana/kibana.yml
@@ -73,13 +73,33 @@ spec:
           env:
             - name: ELASTICSEARCH_URL
               value: "http://elasticsearch:9200"
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=800"
+            - name: MONITORING_UI_ENABLED
+              value: "false"
+            - name: APM_ENABLED
+              value: "false"
+            - name: TIMELION_ENABLED
+              value: "false"
+            - name: MAPS_ENABLED
+              value: "false"
+            - name: GRAPH_ENABLED
+              value: "false"
+            - name: INFRA_ENABLED
+              value: "false"
+            - name: CANVAS_ENABLED
+              value: "false"
+            - name: ML_ENABLED
+              value: "false"
+            - name: UPTIME_ENABLED
+              value: "false"
           resources:
             requests:
               cpu: 100m
-              memory: 500Mi
+              memory: 1024Mi
             limits:
               cpu: "2"
-              memory: 800Mi
+              memory: 1024Mi
         - name: kibana-index-patterns
           image: docker.elastic.co/kibana/kibana
           securityContext:


### PR DESCRIPTION
this will enable kibana to waste less resource on unused plugin in the background and will also help with a correct dimension of heap memory.
new indexpattern will be default in the future since we added the eventlogger on our logging module.
all of this can be easily tuned by a patch.