### PR TITLE
feat(fluentd): update fluentbit to 1.9.5 to address SA token issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: logging/cerebro
-    version: "v1.10.2"
+    version: "v1.10.3"
   - name: logging/curator
-    version: "v1.10.2"
+    version: "v1.10.3"
   - name: logging/elasticsearch-single
-    version: "v1.10.2"
+    version: "v1.10.3"
   - name: logging/fluentd
-    version: "v1.10.2"
+    version: "v1.10.3"
   - name: logging/kibana
-    version: "v1.10.2"
+    version: "v1.10.3"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -15,7 +15,8 @@
 | v1.9.0                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |           |
 | v1.10.0                             |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
 | v1.10.1                             |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
-| v1.10.2                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.10.2                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :warning:          | :warning:          | :warning: |
+| v1.10.3                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.10.3.md
+++ b/docs/releases/v1.10.3.md
@@ -1,0 +1,35 @@
+# Logging Core Module Release 1.10.3
+
+Welcome to the latest release of `logging` module of [`Kubernetes Fury
+Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
+SIGHUP.
+
+This is a patch release fixing fluent-bit stale token problem. Up until Kubernetes 1.20, Service Accounts did NOT expire.
+From K8s 1.21, Service Accounts are set to expire. This will cause applications using expired tokens to stop working.
+
+> 💡 Please refer the release notes of the minor version
+> [`v1.10.3`](https://github.com/sighupio/fury-kubernetes-logging/releases/tag/v1.10.3)
+> if you are upgrading from a version `< v1.10.3`
+
+## Component Images 🚢
+
+| Component       | Supported Version                                                                                      | Previous Version |
+|-----------------|--------------------------------------------------------------------------------------------------------|------------------|
+| `elasticsearch` | [`v7.16.2`](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.3.html) | `No update`      |
+| `kibana`        | [`v7.16.2`](https://www.elastic.co/guide/en/kibana/current/release-notes-7.16.2.html)                  | `No update`      |
+| `cerebro`       | [`v0.9.4`](https://github.com/lmenezes/cerebro/releases/tag/v0.9.4)                                    | `No update`      |
+| `curator`       | [`v5.8.4`](https://github.com/elastic/curator/releases/tag/v5.8.4)                                     | `No update`      |
+| `fluentd`       | [`v1.14.2`](https://github.com/fluent/fluentd/releases/tag/v1.14.2)                                    | `No update`      |
+| `fluent-bit`    | [`v1.9.5`](https://fluentbit.io/announcements/v1.9.5/)                                               | `v1.8.10`      |
+
+> Please refer the individual release notes to get a detailed info on the releases.
+
+## Update Guide 🦮
+
+#### Process
+
+The only package that was upgraded in this patch release is fluentd. To upgrade the package run:
+
+```bash
+kustomize build katalog/fluentd | kubectl apply -f -
+```

--- a/examples/cerebro-deployment/Furyfile.yml
+++ b/examples/cerebro-deployment/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: logging/cerebro
-    version: v1.10.2
+    version: v1.10.3

--- a/examples/curator-s3-deployment-with-jaeger/Furyfile.yml
+++ b/examples/curator-s3-deployment-with-jaeger/Furyfile.yml
@@ -4,6 +4,6 @@
 
 resources:
   - name: logging/curator-s3
-    version: v1.10.2
+    version: v1.10.3
   - name: logging/elasticsearch-single
-    version: v1.10.2
+    version: v1.10.3

--- a/examples/curator-s3-deployment/Furyfile.yml
+++ b/examples/curator-s3-deployment/Furyfile.yml
@@ -4,6 +4,6 @@
 
 bases:
   - name: logging/curator-s3
-    version: v1.10.2
+    version: v1.10.3
   - name: logging/elasticsearch-single
-    version: v1.10.2
+    version: v1.10.3

--- a/examples/elasticsearch-resources/Furyfile.yml
+++ b/examples/elasticsearch-resources/Furyfile.yml
@@ -4,6 +4,6 @@
 
 bases:
   - name: logging/elasticsearch-single
-    version: v1.10.2
+    version: v1.10.3
   - name: monitoring/prometheus-operator
     version: master

--- a/examples/kibana-node-selector/Furyfile.yml
+++ b/examples/kibana-node-selector/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: logging/kibana
-    version: v1.10.2
+    version: v1.10.3

--- a/katalog/fluentd/kustomization.yaml
+++ b/katalog/fluentd/kustomization.yaml
@@ -20,7 +20,7 @@ images:
     newTag: v1.14.2-debian-1.0
   - name: fluent/fluent-bit
     newName: registry.sighup.io/fury/fluent/fluent-bit
-    newTag: 1.8.10
+    newTag: 1.9.5
 
 configMapGenerator:
 - name: fluentd-conf


### PR DESCRIPTION
This PR addresses the problem of the stale SA that fluentbit uses. 

> This problem occours since Kubernetes 1.21 changed the way Service Accounts work. Service accounts are auth tokens used by applications to talk with the masters. Up until Kubernetes 1.20, Service Accounts did NOT expire. From K8s 1.21, Service Accounts are set to expire. This will cause applications using expired tokens to stop working