### PR TITLE
feat(fluentbit): backporting fluent bit 1.9.5 sa problem to v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     Kubernetes Fury Logging
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v2.0.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v2.0.2-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-logging?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -70,19 +70,19 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: logging/cerebro
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/curator
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/elasticsearch-single
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/logging-operator
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/logging-operated
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/configs
-    version: "v2.0.1"
+    version: "v2.0.2"
   - name: logging/kibana
-    version: "v2.0.1"
+    version: "v2.0.2"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -15,9 +15,11 @@
 | v1.9.0                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |           |
 | v1.10.0                             |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
 | v1.10.1                             |                    |                    |                    |                    |                    |                    | :x:                | :x:                | :x:                | :x:       |
-| v1.10.2                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.10.2                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :warning:          | :warning:          | :warning: |
+| v1.10.3                             |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 | v2.0.0                              |                    |                    |                    |                    |                    |                    | :warning:          | :warning:          | :warning:          | :warning: |
-| v2.0.1                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v2.0.1                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :warning:          | :warning:          | :warning: |
+| v2.0.2                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 
 - :white_check_mark: Compatible

--- a/docs/releases/v2.0.2.md
+++ b/docs/releases/v2.0.2.md
@@ -23,6 +23,7 @@ From K8s 1.21, Service Accounts are set to expire. This will cause applications 
   version `v3.17.7`.
 - [#81](https://github.com/sighupio/fury-kubernetes-logging/pull/81) tuned Kibana values and removed unused plugins.
   Thanks to @nohant.
+- Fix audit nodeSelector, from `node.kubernetes.io/role: master` to `node-role.kubernetes.io/master: ""`  
 
 
 

--- a/docs/releases/v2.0.2.md
+++ b/docs/releases/v2.0.2.md
@@ -1,0 +1,34 @@
+# Logging Core Module Release 2.0.1
+
+Welcome to the latest release of `logging` module of [`Kubernetes Fury
+Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
+SIGHUP.
+
+This is a patch release fixing fluent-bit stale token problem. Up until Kubernetes 1.20, Service Accounts did NOT expire.
+From K8s 1.21, Service Accounts are set to expire. This will cause applications using expired tokens to stop working.
+
+## Component Images 🚢
+
+| Component          | Supported Version                                                                                      | Previous Version |
+|--------------------|--------------------------------------------------------------------------------------------------------|------------------|
+| `elasticsearch`    | [`v7.16.2`](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.3.html) | `No update`      |
+| `kibana`           | [`v7.16.2`](https://www.elastic.co/guide/en/kibana/current/release-notes-7.16.2.html)                  | `No update`      |
+| `cerebro`          | [`v0.9.4`](https://github.com/lmenezes/cerebro/releases/tag/v0.9.4)                                    | `No update`      |
+| `curator`          | [`v5.8.4`](https://github.com/elastic/curator/releases/tag/v5.8.4)                                     | `No update`      |
+| `logging-operator` | [`v3.17.7`](https://github.com/banzaicloud/logging-operator/releases/tag/3.17.2)                       | `v3.17.2`        |
+
+## Bug Fixes and Changes 🐛
+
+- Update fluent-bit image in the Logging stack to `v1.9.5` to fix stale SA token issue and update logging-operator to
+  version `v3.17.7`.
+- [#81](https://github.com/sighupio/fury-kubernetes-logging/pull/81) tuned Kibana values and removed unused plugins.
+  Thanks to @nohant.
+
+
+
+
+
+
+
+
+

--- a/docs/releases/v2.0.2.md
+++ b/docs/releases/v2.0.2.md
@@ -1,4 +1,4 @@
-# Logging Core Module Release 2.0.1
+# Logging Core Module Release 2.0.2
 
 Welcome to the latest release of `logging` module of [`Kubernetes Fury
 Distribution`](https://github.com/sighupio/fury-distribution) maintained by team

--- a/katalog/configs/audit/audit-hosttailer.yml
+++ b/katalog/configs/audit/audit-hosttailer.yml
@@ -18,7 +18,7 @@ spec:
         image: registry.sighup.io/fury/fluent/fluent-bit:1.6.1
   workloadOverrides:
     nodeSelector:
-      node.kubernetes.io/role: master
+      node-role.kubernetes.io/master: ""
     tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -12,7 +12,7 @@ spec:
   fluentd:
     image:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
-      tag: v1.14.5-alpine-1
+      tag: v1.14.6-alpine-5
     configReloaderImage:
       repository: registry.sighup.io/fury/jimmidyson/configmap-reload
       tag: v0.4.0
@@ -48,7 +48,7 @@ spec:
   fluentbit:
     image:
       repository: registry.sighup.io/fury/fluent/fluent-bit
-      tag: 1.8.15
+      tag: 1.9.5
     enableUpstream: true
     inputTail:
       Ignore_Older: 86400s

--- a/katalog/logging-operator/README.md
+++ b/katalog/logging-operator/README.md
@@ -15,7 +15,7 @@ and a Fluentd StatefulSet that receive logs from Fluent-bit and send them to var
 
 ## Image repository and tag
 
-* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.0`
+* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.7`
 * Logging operator repo: [Logging operator on GitHub][logging-operator-github]
 
 ## Configuration

--- a/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -313,6 +313,8 @@ spec:
                       type: string
                     path:
                       type: string
+                    read_from_head:
+                      type: boolean
                     skip_long_lines:
                       type: string
                   required:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
@@ -106,6 +106,25 @@ spec:
                         stream:
                           type: string
                       type: object
+                    elasticsearch_genid:
+                      properties:
+                        hash_id_key:
+                          type: string
+                        hash_type:
+                          type: string
+                        include_tag_in_seed:
+                          type: boolean
+                        include_time_in_seed:
+                          type: boolean
+                        record_keys:
+                          type: string
+                        separator:
+                          type: string
+                        use_entire_record:
+                          type: boolean
+                        use_record_as_seed:
+                          type: boolean
+                      type: object
                     enhanceK8s:
                       properties:
                         api_groups:
@@ -369,6 +388,8 @@ spec:
                           type: string
                         parse:
                           properties:
+                            custom_pattern_path:
+                              type: string
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -381,6 +402,31 @@ spec:
                               type: string
                             format_firstline:
                               type: string
+                            grok_failure_key:
+                              type: string
+                            grok_name_key:
+                              type: string
+                            grok_pattern:
+                              type: string
+                            grok_patterns:
+                              items:
+                                properties:
+                                  keep_time_key:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  pattern:
+                                    type: string
+                                  time_format:
+                                    type: string
+                                  time_key:
+                                    type: string
+                                  timezone:
+                                    type: string
+                                required:
+                                - pattern
+                                type: object
+                              type: array
                             keep_time_key:
                               type: boolean
                             keys:
@@ -389,6 +435,8 @@ spec:
                               type: string
                             local_time:
                               type: boolean
+                            multi_line_start_regexp:
+                              type: string
                             multiline:
                               items:
                                 type: string
@@ -448,6 +496,8 @@ spec:
                         parsers:
                           items:
                             properties:
+                              custom_pattern_path:
+                                type: string
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -460,6 +510,31 @@ spec:
                                 type: string
                               format_firstline:
                                 type: string
+                              grok_failure_key:
+                                type: string
+                              grok_name_key:
+                                type: string
+                              grok_pattern:
+                                type: string
+                              grok_patterns:
+                                items:
+                                  properties:
+                                    keep_time_key:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                  required:
+                                  - pattern
+                                  type: object
+                                type: array
                               keep_time_key:
                                 type: boolean
                               keys:
@@ -468,6 +543,8 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
+                              multi_line_start_regexp:
+                                type: string
                               multiline:
                                 items:
                                   type: string
@@ -858,6 +935,25 @@ spec:
                         stream:
                           type: string
                       type: object
+                    elasticsearch_genid:
+                      properties:
+                        hash_id_key:
+                          type: string
+                        hash_type:
+                          type: string
+                        include_tag_in_seed:
+                          type: boolean
+                        include_time_in_seed:
+                          type: boolean
+                        record_keys:
+                          type: string
+                        separator:
+                          type: string
+                        use_entire_record:
+                          type: boolean
+                        use_record_as_seed:
+                          type: boolean
+                      type: object
                     enhanceK8s:
                       properties:
                         api_groups:
@@ -1121,6 +1217,8 @@ spec:
                           type: string
                         parse:
                           properties:
+                            custom_pattern_path:
+                              type: string
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -1133,6 +1231,31 @@ spec:
                               type: string
                             format_firstline:
                               type: string
+                            grok_failure_key:
+                              type: string
+                            grok_name_key:
+                              type: string
+                            grok_pattern:
+                              type: string
+                            grok_patterns:
+                              items:
+                                properties:
+                                  keep_time_key:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  pattern:
+                                    type: string
+                                  time_format:
+                                    type: string
+                                  time_key:
+                                    type: string
+                                  timezone:
+                                    type: string
+                                required:
+                                - pattern
+                                type: object
+                              type: array
                             keep_time_key:
                               type: boolean
                             keys:
@@ -1141,6 +1264,8 @@ spec:
                               type: string
                             local_time:
                               type: boolean
+                            multi_line_start_regexp:
+                              type: string
                             multiline:
                               items:
                                 type: string
@@ -1200,6 +1325,8 @@ spec:
                         parsers:
                           items:
                             properties:
+                              custom_pattern_path:
+                                type: string
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -1212,6 +1339,31 @@ spec:
                                 type: string
                               format_firstline:
                                 type: string
+                              grok_failure_key:
+                                type: string
+                              grok_name_key:
+                                type: string
+                              grok_pattern:
+                                type: string
+                              grok_patterns:
+                                items:
+                                  properties:
+                                    keep_time_key:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                  required:
+                                  - pattern
+                                  type: object
+                                type: array
                               keep_time_key:
                                 type: boolean
                               keys:
@@ -1220,6 +1372,8 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
+                              multi_line_start_regexp:
+                                type: string
                               multiline:
                                 items:
                                   type: string

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -44,6 +44,41 @@ spec:
             properties:
               awsElasticsearch:
                 properties:
+                  api_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  application_name:
+                    type: string
                   buffer:
                     properties:
                       chunk_full_threshold:
@@ -113,6 +148,160 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  content_type:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  data_stream_enable:
+                    type: boolean
+                  data_stream_ilm_name:
+                    type: string
+                  data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  default_elasticsearch_version:
+                    type: string
+                  deflector_alias:
+                    type: string
+                  enable_ilm:
+                    type: boolean
                   endpoint:
                     properties:
                       access_key_id:
@@ -351,6 +540,14 @@ spec:
                       url:
                         type: string
                     type: object
+                  exception_backup:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
                   flush_interval:
                     type: string
                   format:
@@ -370,17 +567,197 @@ spec:
                         - single_value
                         type: string
                     type: object
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  ilm_policy:
+                    type: string
+                  ilm_policy_id:
+                    type: string
+                  ilm_policy_overwrite:
+                    type: boolean
+                  include_index_in_url:
+                    type: boolean
                   include_tag_key:
                     type: boolean
                   include_timestamp:
+                    type: boolean
+                  index_date_pattern:
                     type: string
                   index_name:
+                    type: string
+                  index_prefix:
+                    type: string
+                  log_es_400_reason:
+                    type: boolean
+                  logstash_dateformat:
                     type: string
                   logstash_format:
                     type: boolean
                   logstash_prefix:
                     type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_es_version:
+                    type: string
+                  max_retry_putting_template:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys:
+                    type: string
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  rollover_index:
+                    type: boolean
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_max_version:
+                    type: string
+                  ssl_min_version:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  ssl_version:
+                    type: string
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
                   tag_key:
+                    type: string
+                  target_index_key:
+                    type: string
+                  target_type_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  type_name:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_es_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
                     type: string
                 type: object
               azurestorage:
@@ -790,8 +1167,6 @@ spec:
                   use_tag_as_stream:
                     type: boolean
                 required:
-                - log_group_name
-                - log_stream_name
                 - region
                 type: object
               datadog:
@@ -1298,6 +1673,8 @@ spec:
                     type: boolean
                   reload_on_failure:
                     type: boolean
+                  remove_keys:
+                    type: string
                   remove_keys_on_update:
                     type: string
                   remove_keys_on_update_key:
@@ -3144,6 +3521,10 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_limit:
+                    type: integer
+                  bulk_limit_warning_limit:
+                    type: integer
                   endpoint:
                     properties:
                       port:
@@ -3534,6 +3915,426 @@ spec:
                     type: object
                 type: object
               nullout:
+                type: object
+              opensearch:
+                properties:
+                  application_name:
+                    type: string
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  catch_transport_exception_on_retry:
+                    type: boolean
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  compression_level:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  default_opensearch_version:
+                    type: integer
+                  emit_error_for_missing_id:
+                    type: boolean
+                  emit_error_label_event:
+                    type: boolean
+                  exception_backup:
+                    type: boolean
+                  fail_on_detecting_os_version_retry_exceed:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  http_backend_excon_nonblock:
+                    type: boolean
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  include_index_in_url:
+                    type: boolean
+                  include_tag_key:
+                    type: boolean
+                  include_timestamp:
+                    type: boolean
+                  index_date_pattern:
+                    type: string
+                  index_name:
+                    type: string
+                  index_separator:
+                    type: string
+                  log_os_400_reason:
+                    type: boolean
+                  logstash_dateformat:
+                    type: string
+                  logstash_format:
+                    type: boolean
+                  logstash_prefix:
+                    type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_os_version:
+                    type: integer
+                  max_retry_putting_template:
+                    type: string
+                  parent_key:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  selector_class_name:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
+                  tag_key:
+                    type: string
+                  target_index_affinity:
+                    type: boolean
+                  target_index_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_exclude_timestamp:
+                    type: boolean
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  truncate_caches_interval:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  unrecoverable_record_types:
+                    type: string
+                  use_legacy_template:
+                    type: boolean
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_os_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
+                    type: string
                 type: object
               oss:
                 properties:
@@ -5049,6 +5850,41 @@ spec:
             properties:
               awsElasticsearch:
                 properties:
+                  api_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  application_name:
+                    type: string
                   buffer:
                     properties:
                       chunk_full_threshold:
@@ -5118,6 +5954,160 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  content_type:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  data_stream_enable:
+                    type: boolean
+                  data_stream_ilm_name:
+                    type: string
+                  data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  default_elasticsearch_version:
+                    type: string
+                  deflector_alias:
+                    type: string
+                  enable_ilm:
+                    type: boolean
                   endpoint:
                     properties:
                       access_key_id:
@@ -5356,6 +6346,14 @@ spec:
                       url:
                         type: string
                     type: object
+                  exception_backup:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
                   flush_interval:
                     type: string
                   format:
@@ -5375,17 +6373,197 @@ spec:
                         - single_value
                         type: string
                     type: object
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  ilm_policy:
+                    type: string
+                  ilm_policy_id:
+                    type: string
+                  ilm_policy_overwrite:
+                    type: boolean
+                  include_index_in_url:
+                    type: boolean
                   include_tag_key:
                     type: boolean
                   include_timestamp:
+                    type: boolean
+                  index_date_pattern:
                     type: string
                   index_name:
+                    type: string
+                  index_prefix:
+                    type: string
+                  log_es_400_reason:
+                    type: boolean
+                  logstash_dateformat:
                     type: string
                   logstash_format:
                     type: boolean
                   logstash_prefix:
                     type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_es_version:
+                    type: string
+                  max_retry_putting_template:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys:
+                    type: string
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  rollover_index:
+                    type: boolean
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_max_version:
+                    type: string
+                  ssl_min_version:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  ssl_version:
+                    type: string
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
                   tag_key:
+                    type: string
+                  target_index_key:
+                    type: string
+                  target_type_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  type_name:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_es_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
                     type: string
                 type: object
               azurestorage:
@@ -5795,8 +6973,6 @@ spec:
                   use_tag_as_stream:
                     type: boolean
                 required:
-                - log_group_name
-                - log_stream_name
                 - region
                 type: object
               datadog:
@@ -6303,6 +7479,8 @@ spec:
                     type: boolean
                   reload_on_failure:
                     type: boolean
+                  remove_keys:
+                    type: string
                   remove_keys_on_update:
                     type: string
                   remove_keys_on_update_key:
@@ -8149,6 +9327,10 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_limit:
+                    type: integer
+                  bulk_limit_warning_limit:
+                    type: integer
                   endpoint:
                     properties:
                       port:
@@ -8539,6 +9721,426 @@ spec:
                     type: object
                 type: object
               nullout:
+                type: object
+              opensearch:
+                properties:
+                  application_name:
+                    type: string
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  catch_transport_exception_on_retry:
+                    type: boolean
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  compression_level:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  default_opensearch_version:
+                    type: integer
+                  emit_error_for_missing_id:
+                    type: boolean
+                  emit_error_label_event:
+                    type: boolean
+                  exception_backup:
+                    type: boolean
+                  fail_on_detecting_os_version_retry_exceed:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  http_backend_excon_nonblock:
+                    type: boolean
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  include_index_in_url:
+                    type: boolean
+                  include_tag_key:
+                    type: boolean
+                  include_timestamp:
+                    type: boolean
+                  index_date_pattern:
+                    type: string
+                  index_name:
+                    type: string
+                  index_separator:
+                    type: string
+                  log_os_400_reason:
+                    type: boolean
+                  logstash_dateformat:
+                    type: string
+                  logstash_format:
+                    type: boolean
+                  logstash_prefix:
+                    type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_os_version:
+                    type: integer
+                  max_retry_putting_template:
+                    type: string
+                  parent_key:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  selector_class_name:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
+                  tag_key:
+                    type: string
+                  target_index_affinity:
+                    type: boolean
+                  target_index_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_exclude_timestamp:
+                    type: boolean
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  truncate_caches_interval:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  unrecoverable_record_types:
+                    type: string
+                  use_legacy_template:
+                    type: boolean
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_os_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
+                    type: string
                 type: object
               oss:
                 properties:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
@@ -106,6 +106,25 @@ spec:
                         stream:
                           type: string
                       type: object
+                    elasticsearch_genid:
+                      properties:
+                        hash_id_key:
+                          type: string
+                        hash_type:
+                          type: string
+                        include_tag_in_seed:
+                          type: boolean
+                        include_time_in_seed:
+                          type: boolean
+                        record_keys:
+                          type: string
+                        separator:
+                          type: string
+                        use_entire_record:
+                          type: boolean
+                        use_record_as_seed:
+                          type: boolean
+                      type: object
                     enhanceK8s:
                       properties:
                         api_groups:
@@ -369,6 +388,8 @@ spec:
                           type: string
                         parse:
                           properties:
+                            custom_pattern_path:
+                              type: string
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -381,6 +402,31 @@ spec:
                               type: string
                             format_firstline:
                               type: string
+                            grok_failure_key:
+                              type: string
+                            grok_name_key:
+                              type: string
+                            grok_pattern:
+                              type: string
+                            grok_patterns:
+                              items:
+                                properties:
+                                  keep_time_key:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  pattern:
+                                    type: string
+                                  time_format:
+                                    type: string
+                                  time_key:
+                                    type: string
+                                  timezone:
+                                    type: string
+                                required:
+                                - pattern
+                                type: object
+                              type: array
                             keep_time_key:
                               type: boolean
                             keys:
@@ -389,6 +435,8 @@ spec:
                               type: string
                             local_time:
                               type: boolean
+                            multi_line_start_regexp:
+                              type: string
                             multiline:
                               items:
                                 type: string
@@ -448,6 +496,8 @@ spec:
                         parsers:
                           items:
                             properties:
+                              custom_pattern_path:
+                                type: string
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -460,6 +510,31 @@ spec:
                                 type: string
                               format_firstline:
                                 type: string
+                              grok_failure_key:
+                                type: string
+                              grok_name_key:
+                                type: string
+                              grok_pattern:
+                                type: string
+                              grok_patterns:
+                                items:
+                                  properties:
+                                    keep_time_key:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                  required:
+                                  - pattern
+                                  type: object
+                                type: array
                               keep_time_key:
                                 type: boolean
                               keys:
@@ -468,6 +543,8 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
+                              multi_line_start_regexp:
+                                type: string
                               multiline:
                                 items:
                                   type: string
@@ -854,6 +931,25 @@ spec:
                         stream:
                           type: string
                       type: object
+                    elasticsearch_genid:
+                      properties:
+                        hash_id_key:
+                          type: string
+                        hash_type:
+                          type: string
+                        include_tag_in_seed:
+                          type: boolean
+                        include_time_in_seed:
+                          type: boolean
+                        record_keys:
+                          type: string
+                        separator:
+                          type: string
+                        use_entire_record:
+                          type: boolean
+                        use_record_as_seed:
+                          type: boolean
+                      type: object
                     enhanceK8s:
                       properties:
                         api_groups:
@@ -1117,6 +1213,8 @@ spec:
                           type: string
                         parse:
                           properties:
+                            custom_pattern_path:
+                              type: string
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -1129,6 +1227,31 @@ spec:
                               type: string
                             format_firstline:
                               type: string
+                            grok_failure_key:
+                              type: string
+                            grok_name_key:
+                              type: string
+                            grok_pattern:
+                              type: string
+                            grok_patterns:
+                              items:
+                                properties:
+                                  keep_time_key:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  pattern:
+                                    type: string
+                                  time_format:
+                                    type: string
+                                  time_key:
+                                    type: string
+                                  timezone:
+                                    type: string
+                                required:
+                                - pattern
+                                type: object
+                              type: array
                             keep_time_key:
                               type: boolean
                             keys:
@@ -1137,6 +1260,8 @@ spec:
                               type: string
                             local_time:
                               type: boolean
+                            multi_line_start_regexp:
+                              type: string
                             multiline:
                               items:
                                 type: string
@@ -1196,6 +1321,8 @@ spec:
                         parsers:
                           items:
                             properties:
+                              custom_pattern_path:
+                                type: string
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -1208,6 +1335,31 @@ spec:
                                 type: string
                               format_firstline:
                                 type: string
+                              grok_failure_key:
+                                type: string
+                              grok_name_key:
+                                type: string
+                              grok_pattern:
+                                type: string
+                              grok_patterns:
+                                items:
+                                  properties:
+                                    keep_time_key:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                  required:
+                                  - pattern
+                                  type: object
+                                type: array
                               keep_time_key:
                                 type: boolean
                               keys:
@@ -1216,6 +1368,8 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
+                              multi_line_start_regexp:
+                                type: string
                               multiline:
                                 items:
                                   type: string

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -122,6 +122,25 @@ spec:
                             stream:
                               type: string
                           type: object
+                        elasticsearch_genid:
+                          properties:
+                            hash_id_key:
+                              type: string
+                            hash_type:
+                              type: string
+                            include_tag_in_seed:
+                              type: boolean
+                            include_time_in_seed:
+                              type: boolean
+                            record_keys:
+                              type: string
+                            separator:
+                              type: string
+                            use_entire_record:
+                              type: boolean
+                            use_record_as_seed:
+                              type: boolean
+                          type: object
                         enhanceK8s:
                           properties:
                             api_groups:
@@ -385,6 +404,8 @@ spec:
                               type: string
                             parse:
                               properties:
+                                custom_pattern_path:
+                                  type: string
                                 delimiter:
                                   type: string
                                 delimiter_pattern:
@@ -397,6 +418,31 @@ spec:
                                   type: string
                                 format_firstline:
                                   type: string
+                                grok_failure_key:
+                                  type: string
+                                grok_name_key:
+                                  type: string
+                                grok_pattern:
+                                  type: string
+                                grok_patterns:
+                                  items:
+                                    properties:
+                                      keep_time_key:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      pattern:
+                                        type: string
+                                      time_format:
+                                        type: string
+                                      time_key:
+                                        type: string
+                                      timezone:
+                                        type: string
+                                    required:
+                                    - pattern
+                                    type: object
+                                  type: array
                                 keep_time_key:
                                   type: boolean
                                 keys:
@@ -405,6 +451,8 @@ spec:
                                   type: string
                                 local_time:
                                   type: boolean
+                                multi_line_start_regexp:
+                                  type: string
                                 multiline:
                                   items:
                                     type: string
@@ -464,6 +512,8 @@ spec:
                             parsers:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    type: string
                                   delimiter:
                                     type: string
                                   delimiter_pattern:
@@ -476,6 +526,31 @@ spec:
                                     type: string
                                   format_firstline:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   keys:
@@ -484,6 +559,8 @@ spec:
                                     type: string
                                   local_time:
                                     type: boolean
+                                  multi_line_start_regexp:
+                                    type: string
                                   multiline:
                                     items:
                                       type: string
@@ -734,6 +811,8 @@ spec:
                 type: string
               fluentbit:
                 properties:
+                  HostNetwork:
+                    type: boolean
                   affinity:
                     properties:
                       nodeAffinity:
@@ -1366,6 +1445,8 @@ spec:
                         type: string
                       Buffer_Size:
                         type: string
+                      Cache_Use_Docker_Id:
+                        type: string
                       DNS_Retries:
                         type: string
                       DNS_Wait_Time:
@@ -1628,6 +1709,8 @@ spec:
                         type: string
                       Path_Key:
                         type: string
+                      Read_From_Head:
+                        type: boolean
                       Refresh_Interval:
                         type: string
                       Rotate_Wait:
@@ -4367,6 +4450,25 @@ spec:
                         stream:
                           type: string
                       type: object
+                    elasticsearch_genid:
+                      properties:
+                        hash_id_key:
+                          type: string
+                        hash_type:
+                          type: string
+                        include_tag_in_seed:
+                          type: boolean
+                        include_time_in_seed:
+                          type: boolean
+                        record_keys:
+                          type: string
+                        separator:
+                          type: string
+                        use_entire_record:
+                          type: boolean
+                        use_record_as_seed:
+                          type: boolean
+                      type: object
                     enhanceK8s:
                       properties:
                         api_groups:
@@ -4630,6 +4732,8 @@ spec:
                           type: string
                         parse:
                           properties:
+                            custom_pattern_path:
+                              type: string
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -4642,6 +4746,31 @@ spec:
                               type: string
                             format_firstline:
                               type: string
+                            grok_failure_key:
+                              type: string
+                            grok_name_key:
+                              type: string
+                            grok_pattern:
+                              type: string
+                            grok_patterns:
+                              items:
+                                properties:
+                                  keep_time_key:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  pattern:
+                                    type: string
+                                  time_format:
+                                    type: string
+                                  time_key:
+                                    type: string
+                                  timezone:
+                                    type: string
+                                required:
+                                - pattern
+                                type: object
+                              type: array
                             keep_time_key:
                               type: boolean
                             keys:
@@ -4650,6 +4779,8 @@ spec:
                               type: string
                             local_time:
                               type: boolean
+                            multi_line_start_regexp:
+                              type: string
                             multiline:
                               items:
                                 type: string
@@ -4709,6 +4840,8 @@ spec:
                         parsers:
                           items:
                             properties:
+                              custom_pattern_path:
+                                type: string
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -4721,6 +4854,31 @@ spec:
                                 type: string
                               format_firstline:
                                 type: string
+                              grok_failure_key:
+                                type: string
+                              grok_name_key:
+                                type: string
+                              grok_pattern:
+                                type: string
+                              grok_patterns:
+                                items:
+                                  properties:
+                                    keep_time_key:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    pattern:
+                                      type: string
+                                    time_format:
+                                      type: string
+                                    time_key:
+                                      type: string
+                                    timezone:
+                                      type: string
+                                  required:
+                                  - pattern
+                                  type: object
+                                type: array
                               keep_time_key:
                                 type: boolean
                               keys:
@@ -4729,6 +4887,8 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
+                              multi_line_start_regexp:
+                                type: string
                               multiline:
                                 items:
                                   type: string
@@ -8275,6 +8435,8 @@ spec:
                               type: string
                             Buffer_Size:
                               type: string
+                            Cache_Use_Docker_Id:
+                              type: string
                             DNS_Retries:
                               type: string
                             DNS_Wait_Time:
@@ -8385,6 +8547,8 @@ spec:
                               type: string
                             Path_Key:
                               type: string
+                            Read_From_Head:
+                              type: boolean
                             Refresh_Interval:
                               type: string
                             Rotate_Wait:
@@ -9004,6 +9168,8 @@ spec:
                       type: string
                   type: object
                 type: array
+              skipInvalidResources:
+                type: boolean
               watchNamespaces:
                 items:
                   type: string

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -44,6 +44,41 @@ spec:
             properties:
               awsElasticsearch:
                 properties:
+                  api_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  application_name:
+                    type: string
                   buffer:
                     properties:
                       chunk_full_threshold:
@@ -113,6 +148,160 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  content_type:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  data_stream_enable:
+                    type: boolean
+                  data_stream_ilm_name:
+                    type: string
+                  data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  default_elasticsearch_version:
+                    type: string
+                  deflector_alias:
+                    type: string
+                  enable_ilm:
+                    type: boolean
                   endpoint:
                     properties:
                       access_key_id:
@@ -351,6 +540,14 @@ spec:
                       url:
                         type: string
                     type: object
+                  exception_backup:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
                   flush_interval:
                     type: string
                   format:
@@ -370,17 +567,197 @@ spec:
                         - single_value
                         type: string
                     type: object
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  ilm_policy:
+                    type: string
+                  ilm_policy_id:
+                    type: string
+                  ilm_policy_overwrite:
+                    type: boolean
+                  include_index_in_url:
+                    type: boolean
                   include_tag_key:
                     type: boolean
                   include_timestamp:
+                    type: boolean
+                  index_date_pattern:
                     type: string
                   index_name:
+                    type: string
+                  index_prefix:
+                    type: string
+                  log_es_400_reason:
+                    type: boolean
+                  logstash_dateformat:
                     type: string
                   logstash_format:
                     type: boolean
                   logstash_prefix:
                     type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_es_version:
+                    type: string
+                  max_retry_putting_template:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys:
+                    type: string
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  rollover_index:
+                    type: boolean
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_max_version:
+                    type: string
+                  ssl_min_version:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  ssl_version:
+                    type: string
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
                   tag_key:
+                    type: string
+                  target_index_key:
+                    type: string
+                  target_type_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  type_name:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_es_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
                     type: string
                 type: object
               azurestorage:
@@ -790,8 +1167,6 @@ spec:
                   use_tag_as_stream:
                     type: boolean
                 required:
-                - log_group_name
-                - log_stream_name
                 - region
                 type: object
               datadog:
@@ -1298,6 +1673,8 @@ spec:
                     type: boolean
                   reload_on_failure:
                     type: boolean
+                  remove_keys:
+                    type: string
                   remove_keys_on_update:
                     type: string
                   remove_keys_on_update_key:
@@ -3140,6 +3517,10 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_limit:
+                    type: integer
+                  bulk_limit_warning_limit:
+                    type: integer
                   endpoint:
                     properties:
                       port:
@@ -3530,6 +3911,426 @@ spec:
                     type: object
                 type: object
               nullout:
+                type: object
+              opensearch:
+                properties:
+                  application_name:
+                    type: string
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  catch_transport_exception_on_retry:
+                    type: boolean
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  compression_level:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  default_opensearch_version:
+                    type: integer
+                  emit_error_for_missing_id:
+                    type: boolean
+                  emit_error_label_event:
+                    type: boolean
+                  exception_backup:
+                    type: boolean
+                  fail_on_detecting_os_version_retry_exceed:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  http_backend_excon_nonblock:
+                    type: boolean
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  include_index_in_url:
+                    type: boolean
+                  include_tag_key:
+                    type: boolean
+                  include_timestamp:
+                    type: boolean
+                  index_date_pattern:
+                    type: string
+                  index_name:
+                    type: string
+                  index_separator:
+                    type: string
+                  log_os_400_reason:
+                    type: boolean
+                  logstash_dateformat:
+                    type: string
+                  logstash_format:
+                    type: boolean
+                  logstash_prefix:
+                    type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_os_version:
+                    type: integer
+                  max_retry_putting_template:
+                    type: string
+                  parent_key:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  selector_class_name:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
+                  tag_key:
+                    type: string
+                  target_index_affinity:
+                    type: boolean
+                  target_index_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_exclude_timestamp:
+                    type: boolean
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  truncate_caches_interval:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  unrecoverable_record_types:
+                    type: string
+                  use_legacy_template:
+                    type: boolean
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_os_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
+                    type: string
                 type: object
               oss:
                 properties:
@@ -5043,6 +5844,41 @@ spec:
             properties:
               awsElasticsearch:
                 properties:
+                  api_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  application_name:
+                    type: string
                   buffer:
                     properties:
                       chunk_full_threshold:
@@ -5112,6 +5948,160 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  content_type:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  data_stream_enable:
+                    type: boolean
+                  data_stream_ilm_name:
+                    type: string
+                  data_stream_name:
+                    type: string
+                  data_stream_template_name:
+                    type: string
+                  default_elasticsearch_version:
+                    type: string
+                  deflector_alias:
+                    type: string
+                  enable_ilm:
+                    type: boolean
                   endpoint:
                     properties:
                       access_key_id:
@@ -5350,6 +6340,14 @@ spec:
                       url:
                         type: string
                     type: object
+                  exception_backup:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
                   flush_interval:
                     type: string
                   format:
@@ -5369,17 +6367,197 @@ spec:
                         - single_value
                         type: string
                     type: object
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  ilm_policy:
+                    type: string
+                  ilm_policy_id:
+                    type: string
+                  ilm_policy_overwrite:
+                    type: boolean
+                  include_index_in_url:
+                    type: boolean
                   include_tag_key:
                     type: boolean
                   include_timestamp:
+                    type: boolean
+                  index_date_pattern:
                     type: string
                   index_name:
+                    type: string
+                  index_prefix:
+                    type: string
+                  log_es_400_reason:
+                    type: boolean
+                  logstash_dateformat:
                     type: string
                   logstash_format:
                     type: boolean
                   logstash_prefix:
                     type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_es_version:
+                    type: string
+                  max_retry_putting_template:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys:
+                    type: string
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  rollover_index:
+                    type: boolean
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_max_version:
+                    type: string
+                  ssl_min_version:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  ssl_version:
+                    type: string
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
                   tag_key:
+                    type: string
+                  target_index_key:
+                    type: string
+                  target_type_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  type_name:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_es_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
                     type: string
                 type: object
               azurestorage:
@@ -5789,8 +6967,6 @@ spec:
                   use_tag_as_stream:
                     type: boolean
                 required:
-                - log_group_name
-                - log_stream_name
                 - region
                 type: object
               datadog:
@@ -6297,6 +7473,8 @@ spec:
                     type: boolean
                   reload_on_failure:
                     type: boolean
+                  remove_keys:
+                    type: string
                   remove_keys_on_update:
                     type: string
                   remove_keys_on_update_key:
@@ -8139,6 +9317,10 @@ spec:
                       type:
                         type: string
                     type: object
+                  bulk_limit:
+                    type: integer
+                  bulk_limit_warning_limit:
+                    type: integer
                   endpoint:
                     properties:
                       port:
@@ -8529,6 +9711,426 @@ spec:
                     type: object
                 type: object
               nullout:
+                type: object
+              opensearch:
+                properties:
+                  application_name:
+                    type: string
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  bulk_message_request_threshold:
+                    type: string
+                  ca_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  catch_transport_exception_on_retry:
+                    type: boolean
+                  client_cert:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  client_key_pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  compression_level:
+                    type: string
+                  custom_headers:
+                    type: string
+                  customize_template:
+                    type: string
+                  default_opensearch_version:
+                    type: integer
+                  emit_error_for_missing_id:
+                    type: boolean
+                  emit_error_label_event:
+                    type: boolean
+                  exception_backup:
+                    type: boolean
+                  fail_on_detecting_os_version_retry_exceed:
+                    type: boolean
+                  fail_on_putting_template_retry_exceed:
+                    type: boolean
+                  flatten_hashes:
+                    type: boolean
+                  flatten_hashes_separator:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    type: string
+                  http_backend:
+                    type: string
+                  http_backend_excon_nonblock:
+                    type: boolean
+                  id_key:
+                    type: string
+                  ignore_exceptions:
+                    type: string
+                  include_index_in_url:
+                    type: boolean
+                  include_tag_key:
+                    type: boolean
+                  include_timestamp:
+                    type: boolean
+                  index_date_pattern:
+                    type: string
+                  index_name:
+                    type: string
+                  index_separator:
+                    type: string
+                  log_os_400_reason:
+                    type: boolean
+                  logstash_dateformat:
+                    type: string
+                  logstash_format:
+                    type: boolean
+                  logstash_prefix:
+                    type: string
+                  logstash_prefix_separator:
+                    type: string
+                  max_retry_get_os_version:
+                    type: integer
+                  max_retry_putting_template:
+                    type: string
+                  parent_key:
+                    type: string
+                  password:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  path:
+                    type: string
+                  pipeline:
+                    type: string
+                  port:
+                    type: integer
+                  prefer_oj_serializer:
+                    type: boolean
+                  reconnect_on_error:
+                    type: boolean
+                  reload_after:
+                    type: string
+                  reload_connections:
+                    type: boolean
+                  reload_on_failure:
+                    type: boolean
+                  remove_keys_on_update:
+                    type: string
+                  remove_keys_on_update_key:
+                    type: string
+                  request_timeout:
+                    type: string
+                  resurrect_after:
+                    type: string
+                  retry_tag:
+                    type: string
+                  routing_key:
+                    type: string
+                  scheme:
+                    type: string
+                  selector_class_name:
+                    type: string
+                  sniffer_class_name:
+                    type: string
+                  ssl_verify:
+                    type: boolean
+                  suppress_doc_wrap:
+                    type: boolean
+                  suppress_type_name:
+                    type: boolean
+                  tag_key:
+                    type: string
+                  target_index_affinity:
+                    type: boolean
+                  target_index_key:
+                    type: string
+                  template_file:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  template_name:
+                    type: string
+                  template_overwrite:
+                    type: boolean
+                  templates:
+                    type: string
+                  time_key:
+                    type: string
+                  time_key_exclude_timestamp:
+                    type: boolean
+                  time_key_format:
+                    type: string
+                  time_parse_error_tag:
+                    type: string
+                  time_precision:
+                    type: string
+                  truncate_caches_interval:
+                    type: string
+                  unrecoverable_error_types:
+                    type: string
+                  unrecoverable_record_types:
+                    type: string
+                  use_legacy_template:
+                    type: boolean
+                  user:
+                    type: string
+                  utc_index:
+                    type: boolean
+                  validate_client_version:
+                    type: boolean
+                  verify_os_version_at_startup:
+                    type: boolean
+                  with_transporter_log:
+                    type: boolean
+                  write_operation:
+                    type: string
                 type: object
               oss:
                 properties:

--- a/katalog/logging-operator/deploy.yaml
+++ b/katalog/logging-operator/deploy.yaml
@@ -11,9 +11,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.6
+    helm.sh/chart: logging-operator-3.17.7
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/version: "3.17.7"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: logging-operator/templates/clusterrole.yaml
@@ -339,9 +339,9 @@ metadata:
   name: logging-operator
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.6
+    helm.sh/chart: logging-operator-3.17.7
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/version: "3.17.7"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -360,7 +360,7 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.0
+    helm.sh/chart: logging-operator-3.17.7
     app.kubernetes.io/instance: logging-operator
 spec:
   type: ClusterIP
@@ -382,9 +382,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.6
+    helm.sh/chart: logging-operator-3.17.7
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/version: "3.17.7"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/katalog/logging-operator/deploy.yaml
+++ b/katalog/logging-operator/deploy.yaml
@@ -11,8 +11,10 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.0
+    helm.sh/chart: logging-operator-3.17.6
     app.kubernetes.io/instance: logging-operator
+    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/managed-by: Helm
 ---
 # Source: logging-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -52,6 +54,7 @@ rules:
   - endpoints
   - namespaces
   - nodes
+  - nodes/proxy
   verbs:
   - get
   - list
@@ -336,8 +339,10 @@ metadata:
   name: logging-operator
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.0
+    helm.sh/chart: logging-operator-3.17.6
     app.kubernetes.io/instance: logging-operator
+    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
     name: logging-operator
@@ -377,8 +382,10 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.0
+    helm.sh/chart: logging-operator-3.17.6
     app.kubernetes.io/instance: logging-operator
+    app.kubernetes.io/version: "3.17.6"
+    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   selector:

--- a/katalog/logging-operator/kustomization.yaml
+++ b/katalog/logging-operator/kustomization.yaml
@@ -15,5 +15,5 @@ resources:
 images:
   - name: ghcr.io/banzaicloud/logging-operator
     newName: registry.sighup.io/fury/banzaicloud/logging-operator
-    newTag: 3.17.6
+    newTag: 3.17.7
 

--- a/katalog/logging-operator/kustomization.yaml
+++ b/katalog/logging-operator/kustomization.yaml
@@ -15,5 +15,5 @@ resources:
 images:
   - name: ghcr.io/banzaicloud/logging-operator
     newName: registry.sighup.io/fury/banzaicloud/logging-operator
-    newTag: 3.17.2
+    newTag: 3.17.6
 


### PR DESCRIPTION
This PR addresses the problem of the stale SA that fluentbit uses. 

> This problem occours since Kubernetes 1.21 changed the way Service Accounts work. Service accounts are auth tokens used by applications to talk with the masters. Up until Kubernetes 1.20, Service Accounts did NOT expire. From K8s 1.21, Service Accounts are set to expire. This will cause applications using expired tokens to stop working