### PR TITLE
fix(monitoring): fix description field for alerts

### DIFF
--- a/katalog/opensearch-single/MAINTENANCE.md
+++ b/katalog/opensearch-single/MAINTENANCE.md
@@ -1,8 +1,8 @@
 # OpenSearch - maintenance
 
-To maintain the Opensearch package, you should follow this steps.
+To maintain the OpenSearch package, you should follow this steps.
 
-Download the latest zip from [Opensearch Helm Charts][opensearch-helm-charts].
+Download the latest zip from [OpenSearch Helm Charts][opensearch-helm-charts].
 
 Extract to a folder of your choice, for example: `/tmp/opensearch`.
 
@@ -21,7 +21,6 @@ helm template opensearch /tmp/opensearch -n logging > opensearch-built.yaml
 
 With the `opensearch-built.yaml` file, check differences with the current `deploy.yml` file and change accordingly.
 
-
 What was customized:
 
 - default storage from 8Gi to 30Gi
@@ -29,6 +28,7 @@ What was customized:
 - replace initContainer definition
 - configured requests and limits + java opts for xms and xmx
 - added prometheus exporter
+- added custom prometheus AlertRules
 - opensearch-cluster-master-config created with configMapGenerator instead of in-line configMap
 - customized internal_users.yml config file with opensearch-internal-users secret
 - security plugin is disabled, we expect security on the ingress level or configured manually

--- a/katalog/opensearch-single/rules.yml
+++ b/katalog/opensearch-single/rules.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            message: 'OpenSearch Cluster status is Red, cluster: {{ $labels.cluster }})'
+            description: 'OpenSearch Cluster status is Red, cluster: {{ $labels.cluster }})'
             doc: "OpenSearch Cluster status is Red in the last 30 minutes."
         - alert: OpenSearchClusterYellow
           expr: elasticsearch_cluster_health_status{color="yellow"} == 1
@@ -29,7 +29,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: 'OpenSearch Cluster status is Yellow, cluster: {{ $labels.cluster }})'
+            description: 'OpenSearch Cluster status is Yellow, cluster: {{ $labels.cluster }})'
             doc: "OpenSearch Cluster status is Yellow in the last 30 minutes."
         - alert: OpenSearchNumberOfRelocationShards
           expr: elasticsearch_cluster_health_relocating_shards > 0
@@ -37,7 +37,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: 'Number of relocationg shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
+            description: 'Number of relocationg shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
             doc: "Number of relocation shards for 30 min"
         - alert: OpenSearchNumberOfInitializingShards
           expr: elasticsearch_cluster_health_initializing_shards > 0
@@ -45,7 +45,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: 'Number of initializing shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
+            description: 'Number of initializing shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
             doc: "Number of initializing shards in the last 30 min."
         - alert: OpenSearchNumberOfUnassignedShards
           expr: elasticsearch_cluster_health_unassigned_shards > 0
@@ -53,7 +53,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: 'Number of unassigned shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
+            description: 'Number of unassigned shards in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
             doc: "Number of unassigned shards in the last 30 min."
         - alert: OpenSearchNumberOfPendingTasks
           expr: elasticsearch_cluster_health_number_of_pending_tasks > 0
@@ -61,5 +61,5 @@ spec:
           labels:
             severity: warning
           annotations:
-            message: 'Number of pending tasks in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
+            description: 'Number of pending tasks in the last 30 min: {{ $value }} in the cluster: {{ $labels.cluster }}'
             doc: "Number of pending tasks in the last 30 min."


### PR DESCRIPTION
Align the field used to describe the alert with what we are using in the rest of the alerts and in the AlertManager template for the Slack notifications.