### PR TITLE
fix(configs): use Affinity instead of nodeSelector

### DIFF
--- a/katalog/configs/audit/audit-hosttailer.yml
+++ b/katalog/configs/audit/audit-hosttailer.yml
@@ -18,16 +18,15 @@ spec:
         image: registry.sighup.io/fury/fluent/fluent-bit:1.6.1
   workloadOverrides:
     affinity:
-      value:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+            - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
     tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/katalog/configs/audit/audit-hosttailer.yml
+++ b/katalog/configs/audit/audit-hosttailer.yml
@@ -17,11 +17,17 @@ spec:
       containerOverrides:
         image: registry.sighup.io/fury/fluent/fluent-bit:1.6.1
   workloadOverrides:
-    nodeSelector:
-      node-role.kubernetes.io/master: ""
+    affinity:
+      value:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
     tolerations:
       - operator: Exists
         effect: NoSchedule
-
-
-

--- a/katalog/configs/systemd/etcd/hosttrailer.yml
+++ b/katalog/configs/systemd/etcd/hosttrailer.yml
@@ -17,16 +17,15 @@ spec:
         image: registry.sighup.io/fury/fluent/fluent-bit:1.6.1
   workloadOverrides:
     affinity:
-      value:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+            - matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
     tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/katalog/configs/systemd/etcd/hosttrailer.yml
+++ b/katalog/configs/systemd/etcd/hosttrailer.yml
@@ -16,8 +16,17 @@ spec:
       containerOverrides:
         image: registry.sighup.io/fury/fluent/fluent-bit:1.6.1
   workloadOverrides:
-    nodeSelector:
-      node.kubernetes.io/role: master
+    affinity:
+      value:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
     tolerations:
       - operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
Kubeadm for v1.24 and afterwards changed the taint of the master nodes from `master` to `control-plane`.
 Switch nodeSelector to Affinity to be able to include both cases (nodeSelector only allows AND conditions).

 Fixes #97