### PR TITLE
enable buffer with cleanup for error

### DIFF
--- a/katalog/fluentd/conf.d/ingress-controller-output.conf
+++ b/katalog/fluentd/conf.d/ingress-controller-output.conf
@@ -1,10 +1,12 @@
 <filter kubernetes.var.log.containers.nginx-ingress-**.log>
   @type parser
-  format /^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+|-) (?<upstream_response_time>[\d.]+|-) (?<upstream_status>\d+|-) (?<req_id>[^ ]*)/
-  time_format %d/%b/%Y:%H:%M:%S %z
   key_name log
-  types status:integer,body_bytes_sent:integer,request_length:integer,upstream_response_length:integer,upstream_response_time:float,upstream_status:integer
-  reserve_data yes
+  reserve_data true
+  <parse>
+    @type nginx
+    expression /^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+|-) (?<upstream_response_time>[\d.]+|-) (?<upstream_status>\d+|-) (?<req_id>[^ ]*)/
+    time_format %d/%b/%Y:%H:%M:%S %z
+  </parse>
 </filter>
 <filter kubernetes.var.log.containers.nginx-ingress-**.log>
   @type elasticsearch_genid

--- a/katalog/fluentd/fluent.conf
+++ b/katalog/fluentd/fluent.conf
@@ -1,5 +1,7 @@
 <system>
     log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
+    ignore_repeated_log_interval 60s
+    ignore_same_log_interval 60s
     suppress_repeated_stacktrace true
     log_event_verbose false
     process_name fluentd
@@ -41,6 +43,12 @@
   <match **>
     @type "file"
     path "/buffers/errors/fluentd.*.errors"
+    <buffer>
+      @type file
+      compress gzip
+      overflow_action drop_oldest_chunk
+      total_limit_size 3GB
+    </buffer>
   </match>
 </label>
 


### PR DESCRIPTION
This edit will configure fluentd to treat the /buffer/errors as a real buffer (compressed) and will cycle through that unused log since are written to file and never flushed.
The configuration is necessary where a heavy logging infrastructure is working and there are matched pattern error for fluentd.

I also updated the ingress-controller-output configuration because format was deprecated since FluentD 1.0 and we are using 1.14.