### PR TITLE
chore(ci): replace deprek8n, add k8s 1.24

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,8 +2,9 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-kind: pipeline
 name: license
+kind: pipeline
+type: docker
 
 steps:
   - name: check
@@ -13,15 +14,10 @@ steps:
       - go get -u github.com/google/addlicense
       - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
 
-#  - name: checklabels
-#    image: openpolicyagent/conftest:v0.28.1
-#    pull: always
-#    commands:
-#      -  conftest pull https://raw.githubusercontent.com/sighupio/ci-commons/main/conftest/kustomization/kfd-labels.rego
-#      -  conftest test katalog/**/kustomization.yaml
 ---
-kind: pipeline
 name: policeman
+kind: pipeline
+type: docker
 
 depends_on:
   - license
@@ -62,50 +58,52 @@ steps:
       - kustomize build katalog/configs > configs.yml
       - kustomize build katalog/kibana > kibana.yml
 
-  - &deprek8ion
-    name: deprek8ion-cerebro
-    image: eu.gcr.io/swade1987/deprek8ion:1.1.34
+  - &check-deprecated-apis
+    name: check-deprecated-apis-cerebro
+    image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
-    environment:
-      KUBERNETES_MANIFESTS: cerebro.yml
     depends_on:
       - render
     commands:
-      - /conftest test -p /policies $${KUBERNETES_MANIFESTS}
+      # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.24.0
+    environment:
+      KUBERNETES_MANIFESTS: cerebro.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-curator
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-curator
     environment:
       KUBERNETES_MANIFESTS: curator.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-elasticsearch-triple
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-elasticsearch-triple
     environment:
       KUBERNETES_MANIFESTS: elasticsearch-triple.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-logging-operator
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-logging-operator
     environment:
       KUBERNETES_MANIFESTS: logging-operator.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-logging-operated
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-logging-operated
     environment:
       KUBERNETES_MANIFESTS: logging-operated.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-configs
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-configs
     environment:
       KUBERNETES_MANIFESTS: configs.yml
 
-  - <<: *deprek8ion
-    name: deprek8ion-kibana
+  - <<: *check-deprecated-apis
+    name: check-deprecated-apis-kibana
     environment:
       KUBERNETES_MANIFESTS: kibana.yml
 
 ---
-kind: pipeline
 name: unit-test
+kind: pipeline
+type: docker
 
 depends_on:
   - policeman
@@ -138,8 +136,9 @@ steps:
 #      - push
 
 ---
-kind: pipeline
 name: e2e-kubernetes-1.20
+kind: pipeline
+type: docker
 
 depends_on:
   - policeman
@@ -154,7 +153,8 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v2.0
       - refs/tags/**
 
 steps:
@@ -237,8 +237,9 @@ volumes:
   temp: {}
 
 ---
-kind: pipeline
 name: e2e-kubernetes-1.21
+kind: pipeline
+type: docker
 
 depends_on:
   - policeman
@@ -253,7 +254,8 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v2.0
       - refs/tags/**
 
 steps:
@@ -336,8 +338,9 @@ volumes:
   temp: {}
 
 ---
-kind: pipeline
 name: e2e-kubernetes-1.22
+kind: pipeline
+type: docker
 
 depends_on:
   - policeman
@@ -352,7 +355,8 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v2.0
       - refs/tags/**
 
 steps:
@@ -435,8 +439,9 @@ volumes:
   temp: {}
 
 ---
-kind: pipeline
 name: e2e-kubernetes-1.23
+kind: pipeline
+type: docker
 
 depends_on:
   - policeman
@@ -451,7 +456,8 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
+      - refs/heads/main
+      - refs/heads/release-v2.0
       - refs/tags/**
 
 steps:
@@ -534,14 +540,117 @@ volumes:
   temp: {}
 
 ---
+name: e2e-kubernetes-1.24
 kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+node:
+  runner: internal
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/release-v2.0
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-124
+      pipeline_id: cluster-124
+      local_kind_config_path: katalog/tests/kind/config.yml
+      cluster_version: '1.24.0'
+      instance_path: /shared
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:1.1.0_0.7.0_3.1.1_1.9.4_1.24.1_3.8.7_4.21.1
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-124
+      - bats -t katalog/tests/tests.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
+    pull: always
+    depends_on: [ e2e ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-124
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: shared
+    temp: {}
+
+---
 name: release
+kind: pipeline
+type: docker
 
 depends_on:
   - e2e-kubernetes-1.20
   - e2e-kubernetes-1.21
   - e2e-kubernetes-1.22
   - e2e-kubernetes-1.23
+  - e2e-kubernetes-1.24
 
 platform:
   os: linux


### PR DESCRIPTION
- replace deprek8n with fairwinds pluto
- add missing type to pipelines defintion
- add e2e for Kubernetes 1.24 (ported from .drone.yml in main)
- add triggers for branch `release-v2.0`