### PR TITLE
feat: improve opensearch initContainer

### DIFF
--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -134,7 +134,7 @@ spec:
         image: "alpine"
         command: ['sh', '-c']
         args:
-          - 'sysctl -w vm.max_map_count=262144 && sysctl -w fs.file-max=65536 && sysctl -p && chown -R 1000:1000 /usr/share/opensearch/data'
+          - 'chown -R 1000:1000 /usr/share/opensearch/data'
         securityContext:
           privileged: true
           runAsUser: 0

--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -134,7 +134,25 @@ spec:
         image: "alpine"
         command: ['sh', '-c']
         args:
-          - 'chown -R 1000:1000 /usr/share/opensearch/data'
+          - |
+            sysctl -a
+            MAX_MAP_COUNT=$(sysctl -a | grep max_map_count | cut -d " " -f3)
+            if [ "$MAX_MAP_COUNT" -gt "262143" ]; then
+              echo "Nothing to do, vm.max_map_count value is high enough"
+            else
+              echo "Changing vm.max_map_count value to 262144"
+              sysctl -w vm.max_map_count=262144
+              sysctl -p
+            fi
+            FILE_MAX=$(sysctl -a | grep file-max | cut -d " " -f3)
+            if [ "$FILE_MAX" -gt "524287" ]; then
+              echo "Nothing to do, vm.file-max value is high enough"
+            else
+              echo "Changing vm.file-max value to 524288"
+              sysctl -w vm.max_map_count=524288
+              sysctl -p
+            fi
+            chown -R 1000:1000 /usr/share/opensearch/data
         securityContext:
           privileged: true
           runAsUser: 0


### PR DESCRIPTION
This change adds some logic when changing max_map_count and file-max sysctl values, only whn the pre-existing value is lower than a treshold.

Modern systems already have higher values in place, eg: EKS. 