### PR TITLE
nginx double logging format

### DIFF
--- a/katalog/configs/infra/cluster-output.yml
+++ b/katalog/configs/infra/cluster-output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: infra-index-template
           key: infra-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/ingress-nginx/flow.yml
+++ b/katalog/configs/ingress-nginx/flow.yml
@@ -21,14 +21,7 @@ spec:
             - type: regexp
               expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ,]*(?:,\s[^ ,]*)*) (?<upstream_response_length>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<upstream_response_time>(?:[\d.]+|-)(?:,\s(?:[\d.]+|-))*) (?<upstream_status>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<req_id>[[:alnum:]]*)/'
               time_format: "%Y-%m-%dT%H:%M:%S.%L%z"
-              types:
-                request_length: integer
-                request_time: float
-                status: integer
-                body_bytes_sent: integer
-                upstream_response_length: string
-                upstream_response_time: string
-                upstream_status: string
+              types: 'request_length:integer,request_time:float,status:integer,body_bytes_sent:integer,upstream_response_length:string,upstream_response_time:string,upstream_status:string'
             # this handles nginx error log
             - type: regexp
               expression: '/^(?<logtime>\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<log_level>\[[^\s]+\]) (?<message>.*)$/'

--- a/katalog/configs/ingress-nginx/flow.yml
+++ b/katalog/configs/ingress-nginx/flow.yml
@@ -13,19 +13,23 @@ spec:
         de_dot_separator: "_"
         de_dot_nested: true
     - parser:
-        key_name: log
+        key_name: message
         parse:
           type: multi_format
           patterns:
             # this is the nginx access log format from the ingress controller
-            - type: regexp
+            - format: regexp
               expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ,]*(?:,\s[^ ,]*)*) (?<upstream_response_length>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<upstream_response_time>(?:[\d.]+|-)(?:,\s(?:[\d.]+|-))*) (?<upstream_status>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<req_id>[[:alnum:]]*)/'
               time_format: "%Y-%m-%dT%H:%M:%S.%L%z"
               types: 'request_length:integer,request_time:float,status:integer,body_bytes_sent:integer,upstream_response_length:string,upstream_response_time:string,upstream_status:string'
             # this handles nginx error log
-            - type: regexp
+            - format: regexp
               expression: '/^(?<logtime>\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<log_level>\[[^\s]+\]) (?<message>.*)$/'
-              types: 'logtime:string,log_level:string,message: string'
+              types: 'logtime:string,log_level:string,message:string'
+            # catch all ingress nginx logs
+            - format: regexp
+              expression: '/^(?<generic>.*)$/'
+              types: 'generic:string'
   match:
     - select:
         labels:

--- a/katalog/configs/ingress-nginx/flow.yml
+++ b/katalog/configs/ingress-nginx/flow.yml
@@ -25,10 +25,7 @@ spec:
             # this handles nginx error log
             - type: regexp
               expression: '/^(?<logtime>\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<log_level>\[[^\s]+\]) (?<message>.*)$/'
-              types:
-                logtime: string
-                log_level: string
-                message: string
+              types: 'logtime:string,log_level:string,message: string'
   match:
     - select:
         labels:

--- a/katalog/configs/ingress-nginx/flow.yml
+++ b/katalog/configs/ingress-nginx/flow.yml
@@ -13,9 +13,29 @@ spec:
         de_dot_separator: "_"
         de_dot_nested: true
     - parser:
-        remove_key_name_field: true
+        key_name: log
         parse:
-          type: nginx
+          type: multi_format
+          patterns:
+            # this is the nginx access log format from the ingress controller
+            - type: regexp
+              expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ,]*(?:,\s[^ ,]*)*) (?<upstream_response_length>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<upstream_response_time>(?:[\d.]+|-)(?:,\s(?:[\d.]+|-))*) (?<upstream_status>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<req_id>[[:alnum:]]*)/'
+              time_format: "%Y-%m-%dT%H:%M:%S.%L%z"
+              types:
+                request_length: integer
+                request_time: float
+                status: integer
+                body_bytes_sent: integer
+                upstream_response_length: string
+                upstream_response_time: string
+                upstream_status: string
+            # this handles nginx error log
+            - type: regexp
+              expression: '/^(?<logtime>\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<log_level>\[[^\s]+\]) (?<message>.*)$/'
+              types:
+                logtime: string
+                log_level: string
+                message: string
   match:
     - select:
         labels:
@@ -30,14 +50,3 @@ spec:
           type: internal
   localOutputRefs:
     - ingress-nginx
-
-# Alternatively if you want more control over the parsing, you can use the parser below:
-#    - parser:
-#        key_name: log
-#        remove_key_name_field: true
-#        reserve_data: true
-#        parse:
-#          type: regexp
-#          expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+|-) (?<upstream_response_time>[\d.]+|-) (?<upstream_status>\d+|-) (?<req_id>[^ ]*)/'
-#          time_key: time
-#          time_format: '%d/%b/%Y:%H:%M:%S %z'


### PR DESCRIPTION
Hi everyone 👋 ,
this draft will aim to introduce a more fine-grade and error-prone parser, accordingly with what we've experienced in several client. With the `multi_format` plugin, is possible to specify multiple patterns (one for the default nginx controller log format, the other for the error log).
Feel free to adapt/correct/request changes if you see something wrong.
Is a draft because i still need to test it deeply.

Fixes #120 