### PR TITLE
feat: update logging operator to the latest stable version test it with k8s 1.25

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -462,7 +462,6 @@ trigger:
     include:
       - refs/tags/**
 
-load:
 steps:
   - name: prepare-canonical-json
     image: registry.sighup.io/poc/fury-repo-automations:v0.0.3

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,7 +67,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.24.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.25.0
     environment:
       KUBERNETES_MANIFESTS: cerebro.yml
 
@@ -140,208 +140,6 @@ steps:
 #    when:
 #      event:
 #      - push
----
-name: e2e-kubernetes-1.21
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-121
-      pipeline_id: cluster-121
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.21.1'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.21.1_3.8.7_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-121
-      - bats -t katalog/tests/tests.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-121
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-
----
-name: e2e-kubernetes-1.22
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-122
-      pipeline_id: cluster-122
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.22.0'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.22.0_3.8.7_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-122
-      - bats -t katalog/tests/tests.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.24.0
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-122
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-
 ---
 name: e2e-kubernetes-1.23
 kind: pipeline
@@ -543,6 +341,107 @@ steps:
 volumes:
   - name: shared
     temp: {}
+---
+name: e2e-kubernetes-1.25
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+node:
+  runner: internal
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/master
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: custom-cluster-125
+      pipeline_id: cluster-125
+      local_kind_config_path: katalog/tests/kind/config.yml
+      cluster_version: '1.25.3'
+      instance_path: /shared
+      instance_size: 2-extra-large
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+
+  - name: e2e
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.9.0_3.1.1_1.9.4_1.25.3_3.5.3_4.21.1
+    pull: always
+    volumes:
+      - name: shared
+        path: /shared
+    depends_on: [ init ]
+    commands:
+      - export KUBECONFIG=/shared/kube/kubeconfig-125
+      - bats -t katalog/tests/tests.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+    pull: always
+    depends_on: [ e2e ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-125
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: shared
+    temp: {}
 
 ---
 name: release
@@ -550,10 +449,9 @@ kind: pipeline
 type: docker
 
 depends_on:
-  - e2e-kubernetes-1.21
-  - e2e-kubernetes-1.22
   - e2e-kubernetes-1.23
   - e2e-kubernetes-1.24
+  - e2e-kubernetes-1.25
 
 platform:
   os: linux
@@ -564,6 +462,7 @@ trigger:
     include:
       - refs/tags/**
 
+load:
 steps:
   - name: prepare-canonical-json
     image: registry.sighup.io/poc/fury-repo-automations:v0.0.3

--- a/katalog/logging-operated/README.md
+++ b/katalog/logging-operated/README.md
@@ -7,14 +7,14 @@ It also deploys a MinIO instance for storing all the logs rejected from the conf
 
 ## Requirements
 
-- Kubernetes >= `1.20.0`
+- Kubernetes >= `1.23.0`
 - Kustomize >= `v3.5.3`
 - [logging-operator][logging-operator]
 - [prometheus-operator][prometheus-operator]
 
 ## Image repository and tag
 
-* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.0`
+* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.10`
 
 ## Configuration
 

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -14,8 +14,8 @@ spec:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
       tag: v1.14.6-alpine-5
     configReloaderImage:
-      repository: registry.sighup.io/fury/jimmidyson/configmap-reload
-      tag: v0.4.0
+      repository: registry.sighup.io/fury/banzaicloud/config-reloader
+      tag: 0.0.1
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/katalog/logging-operator/MAINTENANCE.md
+++ b/katalog/logging-operator/MAINTENANCE.md
@@ -12,7 +12,7 @@ Run the following command:
 helm template logging-operator ./tmp/logging-operator/charts/logging-operator -n logging > logging-operator-built.yaml
 ```
 
-With the `logging-operator-build.yaml` file, check differences with the current `deploy.yml` file and change accordingly.
+With the `logging-operator-built.yaml` file, check differences with the current `deploy.yml` file and change accordingly.
 
 Eventually update CRDs in the `./crds` folder with the CRDs from the directory
 `./tmp/logging-operator/charts/logging-operator/crds`.

--- a/katalog/logging-operator/README.md
+++ b/katalog/logging-operator/README.md
@@ -10,12 +10,12 @@ and a Fluentd StatefulSet that receive logs from Fluent-bit and send them to var
 
 ## Requirements
 
-- Kubernetes >= `1.20.0`
+- Kubernetes >= `1.23.0`
 - Kustomize >= `v3.5.3`
 
 ## Image repository and tag
 
-* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.7`
+* Logging operator: `ghcr.io/banzaicloud/logging-operator:3.17.10`
 * Logging operator repo: [Logging operator on GitHub][logging-operator-github]
 
 ## Configuration

--- a/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
+++ b/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: eventtailers.logging-extensions.banzaicloud.io
 spec:

--- a/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: hosttailers.logging-extensions.banzaicloud.io
 spec:
@@ -36,6 +36,8 @@ spec:
               fileTailers:
                 items:
                   properties:
+                    buffer_chunk_size:
+                      type: string
                     buffer_max_size:
                       type: string
                     containerOverrides:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterflows.logging.banzaicloud.io
 spec:
@@ -93,6 +93,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        match_tag:
+                          type: string
                         max_bytes:
                           type: integer
                         max_lines:
@@ -389,7 +391,38 @@ spec:
                         parse:
                           properties:
                             custom_pattern_path:
-                              type: string
+                              properties:
+                                mountFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              type: object
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -435,12 +468,12 @@ spec:
                               type: string
                             local_time:
                               type: boolean
-                            multi_line_start_regexp:
-                              type: string
                             multiline:
                               items:
                                 type: string
                               type: array
+                            multiline_start_regexp:
+                              type: string
                             null_empty_string:
                               type: boolean
                             null_value_pattern:
@@ -448,16 +481,76 @@ spec:
                             patterns:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   estimate_current_event:
                                     type: boolean
                                   expression:
                                     type: string
                                   format:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   local_time:
                                     type: boolean
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -497,7 +590,38 @@ spec:
                           items:
                             properties:
                               custom_pattern_path:
-                                type: string
+                                properties:
+                                  mountFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                type: object
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -543,12 +667,12 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
-                              multi_line_start_regexp:
-                                type: string
                               multiline:
                                 items:
                                   type: string
                                 type: array
+                              multiline_start_regexp:
+                                type: string
                               null_empty_string:
                                 type: boolean
                               null_value_pattern:
@@ -556,16 +680,76 @@ spec:
                               patterns:
                                 items:
                                   properties:
+                                    custom_pattern_path:
+                                      properties:
+                                        mountFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      type: object
                                     estimate_current_event:
                                       type: boolean
                                     expression:
                                       type: string
                                     format:
                                       type: string
+                                    grok_failure_key:
+                                      type: string
+                                    grok_name_key:
+                                      type: string
+                                    grok_pattern:
+                                      type: string
+                                    grok_patterns:
+                                      items:
+                                        properties:
+                                          keep_time_key:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          pattern:
+                                            type: string
+                                          time_format:
+                                            type: string
+                                          time_key:
+                                            type: string
+                                          timezone:
+                                            type: string
+                                        required:
+                                        - pattern
+                                        type: object
+                                      type: array
                                     keep_time_key:
                                       type: boolean
                                     local_time:
                                       type: boolean
+                                    multiline_start_regexp:
+                                      type: string
                                     null_empty_string:
                                       type: boolean
                                     null_value_pattern:
@@ -757,6 +941,8 @@ spec:
                     tag_normaliser:
                       properties:
                         format:
+                          type: string
+                        match_tag:
                           type: string
                       type: object
                     throttle:
@@ -922,6 +1108,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        match_tag:
+                          type: string
                         max_bytes:
                           type: integer
                         max_lines:
@@ -1218,7 +1406,38 @@ spec:
                         parse:
                           properties:
                             custom_pattern_path:
-                              type: string
+                              properties:
+                                mountFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              type: object
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -1264,12 +1483,12 @@ spec:
                               type: string
                             local_time:
                               type: boolean
-                            multi_line_start_regexp:
-                              type: string
                             multiline:
                               items:
                                 type: string
                               type: array
+                            multiline_start_regexp:
+                              type: string
                             null_empty_string:
                               type: boolean
                             null_value_pattern:
@@ -1277,16 +1496,76 @@ spec:
                             patterns:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   estimate_current_event:
                                     type: boolean
                                   expression:
                                     type: string
                                   format:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   local_time:
                                     type: boolean
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -1326,7 +1605,38 @@ spec:
                           items:
                             properties:
                               custom_pattern_path:
-                                type: string
+                                properties:
+                                  mountFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                type: object
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -1372,12 +1682,12 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
-                              multi_line_start_regexp:
-                                type: string
                               multiline:
                                 items:
                                   type: string
                                 type: array
+                              multiline_start_regexp:
+                                type: string
                               null_empty_string:
                                 type: boolean
                               null_value_pattern:
@@ -1385,16 +1695,76 @@ spec:
                               patterns:
                                 items:
                                   properties:
+                                    custom_pattern_path:
+                                      properties:
+                                        mountFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      type: object
                                     estimate_current_event:
                                       type: boolean
                                     expression:
                                       type: string
                                     format:
                                       type: string
+                                    grok_failure_key:
+                                      type: string
+                                    grok_name_key:
+                                      type: string
+                                    grok_pattern:
+                                      type: string
+                                    grok_patterns:
+                                      items:
+                                        properties:
+                                          keep_time_key:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          pattern:
+                                            type: string
+                                          time_format:
+                                            type: string
+                                          time_key:
+                                            type: string
+                                          timezone:
+                                            type: string
+                                        required:
+                                        - pattern
+                                        type: object
+                                      type: array
                                     keep_time_key:
                                       type: boolean
                                     local_time:
                                       type: boolean
+                                    multiline_start_regexp:
+                                      type: string
                                     null_empty_string:
                                       type: boolean
                                     null_value_pattern:
@@ -1586,6 +1956,8 @@ spec:
                     tag_normaliser:
                       properties:
                         format:
+                          type: string
+                        match_tag:
                           type: string
                       type: object
                     throttle:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusteroutputs.logging.banzaicloud.io
 spec:
@@ -292,6 +292,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -542,6 +546,8 @@ spec:
                     type: object
                   exception_backup:
                     type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
+                    type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
                   flatten_hashes:
@@ -675,6 +681,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -942,6 +950,8 @@ spec:
                     type: string
                   path:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - azure_container
                 - azure_storage_account
@@ -1162,6 +1172,8 @@ spec:
                     type: string
                   retention_in_days_key:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   use_tag_as_group:
                     type: boolean
                   use_tag_as_stream:
@@ -1296,6 +1308,8 @@ spec:
                   port:
                     type: string
                   service:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_port:
                     type: string
@@ -1564,6 +1578,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -1575,6 +1593,8 @@ spec:
                   enable_ilm:
                     type: boolean
                   exception_backup:
+                    type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
                     type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
@@ -1690,6 +1710,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -1879,6 +1901,8 @@ spec:
                     type: string
                   recompress:
                     type: boolean
+                  slow_flush_log_threshold:
+                    type: string
                   symlink_path:
                     type: boolean
                 required:
@@ -2115,6 +2139,8 @@ spec:
                       - host
                       type: object
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -2427,6 +2453,8 @@ spec:
                     type: string
                   project:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   storage_class:
                     type: string
                   store_as:
@@ -2639,6 +2667,8 @@ spec:
                     items:
                       type: integer
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   ssl_timeout:
                     type: integer
                   tls_ca_cert_path:
@@ -2906,6 +2936,39 @@ spec:
                     type: integer
                   kafka_agg_max_messages:
                     type: integer
+                  keytab:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
                   max_send_retries:
                     type: integer
                   message_key_key:
@@ -2947,11 +3010,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  principal:
+                    type: string
                   required_acks:
                     type: integer
                   sasl_over_ssl:
                     type: boolean
                   scram_mechanism:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
                     properties:
@@ -3354,6 +3421,8 @@ spec:
                     type: boolean
                   retries_on_batch_request:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   stream_name:
                     type: string
                 required:
@@ -3441,6 +3510,8 @@ spec:
                   ingester_endpoint:
                     type: string
                   request_timeout:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   tags:
                     type: string
@@ -3577,6 +3648,8 @@ spec:
                     type: integer
                   retry_sleep:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - endpoint
                 type: object
@@ -3805,6 +3878,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tenant:
                     type: string
                   url:
@@ -4252,6 +4327,8 @@ spec:
                     type: string
                   selector_class_name:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sniffer_class_name:
                     type: string
                   ssl_verify:
@@ -4518,6 +4595,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   store_as:
                     type: string
                   upload_crc_enable:
@@ -4661,6 +4740,8 @@ spec:
                     type: object
                   port:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   strftime_format:
                     type: string
                   ttl:
@@ -4922,6 +5003,8 @@ spec:
                         type: string
                     type: object
                   signature_version:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sse_customer_algorithm:
                     type: string
@@ -5239,6 +5322,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   source:
                     type: string
                   source_key:
@@ -5402,6 +5487,8 @@ spec:
                     type: string
                   region:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sqs_url:
                     type: string
                   tag_property_name:
@@ -5538,6 +5625,8 @@ spec:
                   open_timeout:
                     type: integer
                   proxy_uri:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   source_category:
                     type: string
@@ -5766,6 +5855,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  slow_flush_log_threshold:
+                    type: string
                   transport:
                     type: string
                   trusted_ca_path:
@@ -6098,6 +6189,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -6348,6 +6443,8 @@ spec:
                     type: object
                   exception_backup:
                     type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
+                    type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
                   flatten_hashes:
@@ -6481,6 +6578,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -6748,6 +6847,8 @@ spec:
                     type: string
                   path:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - azure_container
                 - azure_storage_account
@@ -6968,6 +7069,8 @@ spec:
                     type: string
                   retention_in_days_key:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   use_tag_as_group:
                     type: boolean
                   use_tag_as_stream:
@@ -7102,6 +7205,8 @@ spec:
                   port:
                     type: string
                   service:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_port:
                     type: string
@@ -7370,6 +7475,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -7381,6 +7490,8 @@ spec:
                   enable_ilm:
                     type: boolean
                   exception_backup:
+                    type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
                     type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
@@ -7496,6 +7607,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -7685,6 +7798,8 @@ spec:
                     type: string
                   recompress:
                     type: boolean
+                  slow_flush_log_threshold:
+                    type: string
                   symlink_path:
                     type: boolean
                 required:
@@ -7921,6 +8036,8 @@ spec:
                       - host
                       type: object
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -8233,6 +8350,8 @@ spec:
                     type: string
                   project:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   storage_class:
                     type: string
                   store_as:
@@ -8445,6 +8564,8 @@ spec:
                     items:
                       type: integer
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   ssl_timeout:
                     type: integer
                   tls_ca_cert_path:
@@ -8712,6 +8833,39 @@ spec:
                     type: integer
                   kafka_agg_max_messages:
                     type: integer
+                  keytab:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
                   max_send_retries:
                     type: integer
                   message_key_key:
@@ -8753,11 +8907,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  principal:
+                    type: string
                   required_acks:
                     type: integer
                   sasl_over_ssl:
                     type: boolean
                   scram_mechanism:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
                     properties:
@@ -9160,6 +9318,8 @@ spec:
                     type: boolean
                   retries_on_batch_request:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   stream_name:
                     type: string
                 required:
@@ -9247,6 +9407,8 @@ spec:
                   ingester_endpoint:
                     type: string
                   request_timeout:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   tags:
                     type: string
@@ -9383,6 +9545,8 @@ spec:
                     type: integer
                   retry_sleep:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - endpoint
                 type: object
@@ -9611,6 +9775,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tenant:
                     type: string
                   url:
@@ -10058,6 +10224,8 @@ spec:
                     type: string
                   selector_class_name:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sniffer_class_name:
                     type: string
                   ssl_verify:
@@ -10324,6 +10492,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   store_as:
                     type: string
                   upload_crc_enable:
@@ -10467,6 +10637,8 @@ spec:
                     type: object
                   port:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   strftime_format:
                     type: string
                   ttl:
@@ -10728,6 +10900,8 @@ spec:
                         type: string
                     type: object
                   signature_version:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sse_customer_algorithm:
                     type: string
@@ -11045,6 +11219,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   source:
                     type: string
                   source_key:
@@ -11208,6 +11384,8 @@ spec:
                     type: string
                   region:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sqs_url:
                     type: string
                   tag_property_name:
@@ -11344,6 +11522,8 @@ spec:
                   open_timeout:
                     type: integer
                   proxy_uri:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   source_category:
                     type: string
@@ -11572,6 +11752,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  slow_flush_log_threshold:
+                    type: string
                   transport:
                     type: string
                   trusted_ca_path:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: flows.logging.banzaicloud.io
 spec:
@@ -93,6 +93,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        match_tag:
+                          type: string
                         max_bytes:
                           type: integer
                         max_lines:
@@ -389,7 +391,38 @@ spec:
                         parse:
                           properties:
                             custom_pattern_path:
-                              type: string
+                              properties:
+                                mountFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              type: object
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -435,12 +468,12 @@ spec:
                               type: string
                             local_time:
                               type: boolean
-                            multi_line_start_regexp:
-                              type: string
                             multiline:
                               items:
                                 type: string
                               type: array
+                            multiline_start_regexp:
+                              type: string
                             null_empty_string:
                               type: boolean
                             null_value_pattern:
@@ -448,16 +481,76 @@ spec:
                             patterns:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   estimate_current_event:
                                     type: boolean
                                   expression:
                                     type: string
                                   format:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   local_time:
                                     type: boolean
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -497,7 +590,38 @@ spec:
                           items:
                             properties:
                               custom_pattern_path:
-                                type: string
+                                properties:
+                                  mountFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                type: object
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -543,12 +667,12 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
-                              multi_line_start_regexp:
-                                type: string
                               multiline:
                                 items:
                                   type: string
                                 type: array
+                              multiline_start_regexp:
+                                type: string
                               null_empty_string:
                                 type: boolean
                               null_value_pattern:
@@ -556,16 +680,76 @@ spec:
                               patterns:
                                 items:
                                   properties:
+                                    custom_pattern_path:
+                                      properties:
+                                        mountFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      type: object
                                     estimate_current_event:
                                       type: boolean
                                     expression:
                                       type: string
                                     format:
                                       type: string
+                                    grok_failure_key:
+                                      type: string
+                                    grok_name_key:
+                                      type: string
+                                    grok_pattern:
+                                      type: string
+                                    grok_patterns:
+                                      items:
+                                        properties:
+                                          keep_time_key:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          pattern:
+                                            type: string
+                                          time_format:
+                                            type: string
+                                          time_key:
+                                            type: string
+                                          timezone:
+                                            type: string
+                                        required:
+                                        - pattern
+                                        type: object
+                                      type: array
                                     keep_time_key:
                                       type: boolean
                                     local_time:
                                       type: boolean
+                                    multiline_start_regexp:
+                                      type: string
                                     null_empty_string:
                                       type: boolean
                                     null_value_pattern:
@@ -757,6 +941,8 @@ spec:
                     tag_normaliser:
                       properties:
                         format:
+                          type: string
+                        match_tag:
                           type: string
                       type: object
                     throttle:
@@ -918,6 +1104,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        match_tag:
+                          type: string
                         max_bytes:
                           type: integer
                         max_lines:
@@ -1214,7 +1402,38 @@ spec:
                         parse:
                           properties:
                             custom_pattern_path:
-                              type: string
+                              properties:
+                                mountFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              type: object
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -1260,12 +1479,12 @@ spec:
                               type: string
                             local_time:
                               type: boolean
-                            multi_line_start_regexp:
-                              type: string
                             multiline:
                               items:
                                 type: string
                               type: array
+                            multiline_start_regexp:
+                              type: string
                             null_empty_string:
                               type: boolean
                             null_value_pattern:
@@ -1273,16 +1492,76 @@ spec:
                             patterns:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   estimate_current_event:
                                     type: boolean
                                   expression:
                                     type: string
                                   format:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   local_time:
                                     type: boolean
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -1322,7 +1601,38 @@ spec:
                           items:
                             properties:
                               custom_pattern_path:
-                                type: string
+                                properties:
+                                  mountFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                type: object
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -1368,12 +1678,12 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
-                              multi_line_start_regexp:
-                                type: string
                               multiline:
                                 items:
                                   type: string
                                 type: array
+                              multiline_start_regexp:
+                                type: string
                               null_empty_string:
                                 type: boolean
                               null_value_pattern:
@@ -1381,16 +1691,76 @@ spec:
                               patterns:
                                 items:
                                   properties:
+                                    custom_pattern_path:
+                                      properties:
+                                        mountFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      type: object
                                     estimate_current_event:
                                       type: boolean
                                     expression:
                                       type: string
                                     format:
                                       type: string
+                                    grok_failure_key:
+                                      type: string
+                                    grok_name_key:
+                                      type: string
+                                    grok_pattern:
+                                      type: string
+                                    grok_patterns:
+                                      items:
+                                        properties:
+                                          keep_time_key:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          pattern:
+                                            type: string
+                                          time_format:
+                                            type: string
+                                          time_key:
+                                            type: string
+                                          timezone:
+                                            type: string
+                                        required:
+                                        - pattern
+                                        type: object
+                                      type: array
                                     keep_time_key:
                                       type: boolean
                                     local_time:
                                       type: boolean
+                                    multiline_start_regexp:
+                                      type: string
                                     null_empty_string:
                                       type: boolean
                                     null_value_pattern:
@@ -1582,6 +1952,8 @@ spec:
                     tag_normaliser:
                       properties:
                         format:
+                          type: string
+                        match_tag:
                           type: string
                       type: object
                     throttle:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: loggings.logging.banzaicloud.io
 spec:
@@ -54,6 +54,8 @@ spec:
             properties:
               allowClusterResourcesFromAllNamespaces:
                 type: boolean
+              clusterDomain:
+                type: string
               controlNamespace:
                 type: string
               defaultFlow:
@@ -109,6 +111,8 @@ spec:
                               items:
                                 type: string
                               type: array
+                            match_tag:
+                              type: string
                             max_bytes:
                               type: integer
                             max_lines:
@@ -405,7 +409,38 @@ spec:
                             parse:
                               properties:
                                 custom_pattern_path:
-                                  type: string
+                                  properties:
+                                    mountFrom:
+                                      properties:
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  type: object
                                 delimiter:
                                   type: string
                                 delimiter_pattern:
@@ -451,12 +486,12 @@ spec:
                                   type: string
                                 local_time:
                                   type: boolean
-                                multi_line_start_regexp:
-                                  type: string
                                 multiline:
                                   items:
                                     type: string
                                   type: array
+                                multiline_start_regexp:
+                                  type: string
                                 null_empty_string:
                                   type: boolean
                                 null_value_pattern:
@@ -464,16 +499,76 @@ spec:
                                 patterns:
                                   items:
                                     properties:
+                                      custom_pattern_path:
+                                        properties:
+                                          mountFrom:
+                                            properties:
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        type: object
                                       estimate_current_event:
                                         type: boolean
                                       expression:
                                         type: string
                                       format:
                                         type: string
+                                      grok_failure_key:
+                                        type: string
+                                      grok_name_key:
+                                        type: string
+                                      grok_pattern:
+                                        type: string
+                                      grok_patterns:
+                                        items:
+                                          properties:
+                                            keep_time_key:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            pattern:
+                                              type: string
+                                            time_format:
+                                              type: string
+                                            time_key:
+                                              type: string
+                                            timezone:
+                                              type: string
+                                          required:
+                                          - pattern
+                                          type: object
+                                        type: array
                                       keep_time_key:
                                         type: boolean
                                       local_time:
                                         type: boolean
+                                      multiline_start_regexp:
+                                        type: string
                                       null_empty_string:
                                         type: boolean
                                       null_value_pattern:
@@ -513,7 +608,38 @@ spec:
                               items:
                                 properties:
                                   custom_pattern_path:
-                                    type: string
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   delimiter:
                                     type: string
                                   delimiter_pattern:
@@ -559,12 +685,12 @@ spec:
                                     type: string
                                   local_time:
                                     type: boolean
-                                  multi_line_start_regexp:
-                                    type: string
                                   multiline:
                                     items:
                                       type: string
                                     type: array
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -572,16 +698,76 @@ spec:
                                   patterns:
                                     items:
                                       properties:
+                                        custom_pattern_path:
+                                          properties:
+                                            mountFrom:
+                                              properties:
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                              type: object
+                                            value:
+                                              type: string
+                                            valueFrom:
+                                              properties:
+                                                secretKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                              type: object
+                                          type: object
                                         estimate_current_event:
                                           type: boolean
                                         expression:
                                           type: string
                                         format:
                                           type: string
+                                        grok_failure_key:
+                                          type: string
+                                        grok_name_key:
+                                          type: string
+                                        grok_pattern:
+                                          type: string
+                                        grok_patterns:
+                                          items:
+                                            properties:
+                                              keep_time_key:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              pattern:
+                                                type: string
+                                              time_format:
+                                                type: string
+                                              time_key:
+                                                type: string
+                                              timezone:
+                                                type: string
+                                            required:
+                                            - pattern
+                                            type: object
+                                          type: array
                                         keep_time_key:
                                           type: boolean
                                         local_time:
                                           type: boolean
+                                        multiline_start_regexp:
+                                          type: string
                                         null_empty_string:
                                           type: boolean
                                         null_value_pattern:
@@ -773,6 +959,8 @@ spec:
                         tag_normaliser:
                           properties:
                             format:
+                              type: string
+                            match_tag:
                               type: string
                           type: object
                         throttle:
@@ -1305,6 +1493,173 @@ spec:
                             type: object
                         type: object
                     type: object
+                  bufferVolumeArgs:
+                    items:
+                      type: string
+                    type: array
+                  bufferVolumeImage:
+                    properties:
+                      imagePullSecrets:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                      pullPolicy:
+                        type: string
+                      repository:
+                        type: string
+                      tag:
+                        type: string
+                    type: object
+                  bufferVolumeMetrics:
+                    properties:
+                      interval:
+                        type: string
+                      path:
+                        type: string
+                      port:
+                        format: int32
+                        type: integer
+                      prometheusAnnotations:
+                        type: boolean
+                      prometheusRules:
+                        type: boolean
+                      serviceMonitor:
+                        type: boolean
+                      serviceMonitorConfig:
+                        properties:
+                          additionalLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          honorLabels:
+                            type: boolean
+                          metricRelabelings:
+                            items:
+                              properties:
+                                action:
+                                  type: string
+                                modulus:
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  type: string
+                                replacement:
+                                  type: string
+                                separator:
+                                  type: string
+                                sourceLabels:
+                                  items:
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  type: string
+                              type: object
+                            type: array
+                          relabelings:
+                            items:
+                              properties:
+                                action:
+                                  type: string
+                                modulus:
+                                  format: int64
+                                  type: integer
+                                regex:
+                                  type: string
+                                replacement:
+                                  type: string
+                                separator:
+                                  type: string
+                                sourceLabels:
+                                  items:
+                                    type: string
+                                  type: array
+                                targetLabel:
+                                  type: string
+                              type: object
+                            type: array
+                          scheme:
+                            type: string
+                          tlsConfig:
+                            properties:
+                              ca:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              caFile:
+                                type: string
+                              cert:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  secret:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                              certFile:
+                                type: string
+                              insecureSkipVerify:
+                                type: boolean
+                              keyFile:
+                                type: string
+                              keySecret:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              serverName:
+                                type: string
+                            type: object
+                        type: object
+                      timeout:
+                        type: string
+                    type: object
                   coroStackSize:
                     format: int32
                     type: integer
@@ -1677,6 +2032,10 @@ spec:
                         type: string
                       DB:
                         type: string
+                      DB.journal_mode:
+                        type: string
+                      DB.locking:
+                        type: boolean
                       DB_Sync:
                         type: string
                       Docker_Mode:
@@ -2546,6 +2905,24 @@ spec:
                           type: string
                       type: object
                     type: array
+                  updateStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                 type: object
               fluentd:
                 properties:
@@ -3197,6 +3574,8 @@ spec:
                       timeout:
                         type: string
                     type: object
+                  compressConfigFile:
+                    type: boolean
                   configCheckAnnotations:
                     additionalProperties:
                       type: string
@@ -3279,6 +3658,8 @@ spec:
                     type: object
                   dnsPolicy:
                     type: string
+                  enableMsgpackTimeSupport:
+                    type: boolean
                   envVars:
                     items:
                       properties:
@@ -3338,6 +3719,10 @@ spec:
                       required:
                       - name
                       type: object
+                    type: array
+                  extraArgs:
+                    items:
+                      type: string
                     type: array
                   extraVolumes:
                     items:
@@ -4078,6 +4463,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          deleteVolume:
+                            type: boolean
                           enabled:
                             type: boolean
                           image:
@@ -4437,6 +4824,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        match_tag:
+                          type: string
                         max_bytes:
                           type: integer
                         max_lines:
@@ -4733,7 +5122,38 @@ spec:
                         parse:
                           properties:
                             custom_pattern_path:
-                              type: string
+                              properties:
+                                mountFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              type: object
                             delimiter:
                               type: string
                             delimiter_pattern:
@@ -4779,12 +5199,12 @@ spec:
                               type: string
                             local_time:
                               type: boolean
-                            multi_line_start_regexp:
-                              type: string
                             multiline:
                               items:
                                 type: string
                               type: array
+                            multiline_start_regexp:
+                              type: string
                             null_empty_string:
                               type: boolean
                             null_value_pattern:
@@ -4792,16 +5212,76 @@ spec:
                             patterns:
                               items:
                                 properties:
+                                  custom_pattern_path:
+                                    properties:
+                                      mountFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                        type: object
+                                    type: object
                                   estimate_current_event:
                                     type: boolean
                                   expression:
                                     type: string
                                   format:
                                     type: string
+                                  grok_failure_key:
+                                    type: string
+                                  grok_name_key:
+                                    type: string
+                                  grok_pattern:
+                                    type: string
+                                  grok_patterns:
+                                    items:
+                                      properties:
+                                        keep_time_key:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        pattern:
+                                          type: string
+                                        time_format:
+                                          type: string
+                                        time_key:
+                                          type: string
+                                        timezone:
+                                          type: string
+                                      required:
+                                      - pattern
+                                      type: object
+                                    type: array
                                   keep_time_key:
                                     type: boolean
                                   local_time:
                                     type: boolean
+                                  multiline_start_regexp:
+                                    type: string
                                   null_empty_string:
                                     type: boolean
                                   null_value_pattern:
@@ -4841,7 +5321,38 @@ spec:
                           items:
                             properties:
                               custom_pattern_path:
-                                type: string
+                                properties:
+                                  mountFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                  value:
+                                    type: string
+                                  valueFrom:
+                                    properties:
+                                      secretKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                type: object
                               delimiter:
                                 type: string
                               delimiter_pattern:
@@ -4887,12 +5398,12 @@ spec:
                                 type: string
                               local_time:
                                 type: boolean
-                              multi_line_start_regexp:
-                                type: string
                               multiline:
                                 items:
                                   type: string
                                 type: array
+                              multiline_start_regexp:
+                                type: string
                               null_empty_string:
                                 type: boolean
                               null_value_pattern:
@@ -4900,16 +5411,76 @@ spec:
                               patterns:
                                 items:
                                   properties:
+                                    custom_pattern_path:
+                                      properties:
+                                        mountFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                        value:
+                                          type: string
+                                        valueFrom:
+                                          properties:
+                                            secretKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                optional:
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      type: object
                                     estimate_current_event:
                                       type: boolean
                                     expression:
                                       type: string
                                     format:
                                       type: string
+                                    grok_failure_key:
+                                      type: string
+                                    grok_name_key:
+                                      type: string
+                                    grok_pattern:
+                                      type: string
+                                    grok_patterns:
+                                      items:
+                                        properties:
+                                          keep_time_key:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          pattern:
+                                            type: string
+                                          time_format:
+                                            type: string
+                                          time_key:
+                                            type: string
+                                          timezone:
+                                            type: string
+                                        required:
+                                        - pattern
+                                        type: object
+                                      type: array
                                     keep_time_key:
                                       type: boolean
                                     local_time:
                                       type: boolean
+                                    multiline_start_regexp:
+                                      type: string
                                     null_empty_string:
                                       type: boolean
                                     null_value_pattern:
@@ -5101,6 +5672,8 @@ spec:
                     tag_normaliser:
                       properties:
                         format:
+                          type: string
+                        match_tag:
                           type: string
                       type: object
                     throttle:
@@ -8515,6 +9088,10 @@ spec:
                               type: string
                             DB:
                               type: string
+                            DB.journal_mode:
+                              type: string
+                            DB.locking:
+                              type: boolean
                             DB_Sync:
                               type: string
                             Docker_Mode:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: outputs.logging.banzaicloud.io
 spec:
@@ -292,6 +292,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -542,6 +546,8 @@ spec:
                     type: object
                   exception_backup:
                     type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
+                    type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
                   flatten_hashes:
@@ -675,6 +681,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -942,6 +950,8 @@ spec:
                     type: string
                   path:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - azure_container
                 - azure_storage_account
@@ -1162,6 +1172,8 @@ spec:
                     type: string
                   retention_in_days_key:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   use_tag_as_group:
                     type: boolean
                   use_tag_as_stream:
@@ -1296,6 +1308,8 @@ spec:
                   port:
                     type: string
                   service:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_port:
                     type: string
@@ -1564,6 +1578,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -1575,6 +1593,8 @@ spec:
                   enable_ilm:
                     type: boolean
                   exception_backup:
+                    type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
                     type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
@@ -1690,6 +1710,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -1875,6 +1897,8 @@ spec:
                     type: string
                   recompress:
                     type: boolean
+                  slow_flush_log_threshold:
+                    type: string
                   symlink_path:
                     type: boolean
                 required:
@@ -2111,6 +2135,8 @@ spec:
                       - host
                       type: object
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -2423,6 +2449,8 @@ spec:
                     type: string
                   project:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   storage_class:
                     type: string
                   store_as:
@@ -2635,6 +2663,8 @@ spec:
                     items:
                       type: integer
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   ssl_timeout:
                     type: integer
                   tls_ca_cert_path:
@@ -2902,6 +2932,39 @@ spec:
                     type: integer
                   kafka_agg_max_messages:
                     type: integer
+                  keytab:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
                   max_send_retries:
                     type: integer
                   message_key_key:
@@ -2943,11 +3006,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  principal:
+                    type: string
                   required_acks:
                     type: integer
                   sasl_over_ssl:
                     type: boolean
                   scram_mechanism:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
                     properties:
@@ -3350,6 +3417,8 @@ spec:
                     type: boolean
                   retries_on_batch_request:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   stream_name:
                     type: string
                 required:
@@ -3437,6 +3506,8 @@ spec:
                   ingester_endpoint:
                     type: string
                   request_timeout:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   tags:
                     type: string
@@ -3573,6 +3644,8 @@ spec:
                     type: integer
                   retry_sleep:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - endpoint
                 type: object
@@ -3801,6 +3874,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tenant:
                     type: string
                   url:
@@ -4248,6 +4323,8 @@ spec:
                     type: string
                   selector_class_name:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sniffer_class_name:
                     type: string
                   ssl_verify:
@@ -4514,6 +4591,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   store_as:
                     type: string
                   upload_crc_enable:
@@ -4657,6 +4736,8 @@ spec:
                     type: object
                   port:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   strftime_format:
                     type: string
                   ttl:
@@ -4918,6 +4999,8 @@ spec:
                         type: string
                     type: object
                   signature_version:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sse_customer_algorithm:
                     type: string
@@ -5235,6 +5318,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   source:
                     type: string
                   source_key:
@@ -5398,6 +5483,8 @@ spec:
                     type: string
                   region:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sqs_url:
                     type: string
                   tag_property_name:
@@ -5534,6 +5621,8 @@ spec:
                   open_timeout:
                     type: integer
                   proxy_uri:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   source_category:
                     type: string
@@ -5762,6 +5851,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  slow_flush_log_threshold:
+                    type: string
                   transport:
                     type: string
                   trusted_ca_path:
@@ -6092,6 +6183,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -6342,6 +6437,8 @@ spec:
                     type: object
                   exception_backup:
                     type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
+                    type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
                   flatten_hashes:
@@ -6475,6 +6572,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -6742,6 +6841,8 @@ spec:
                     type: string
                   path:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - azure_container
                 - azure_storage_account
@@ -6962,6 +7063,8 @@ spec:
                     type: string
                   retention_in_days_key:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   use_tag_as_group:
                     type: boolean
                   use_tag_as_stream:
@@ -7096,6 +7199,8 @@ spec:
                   port:
                     type: string
                   service:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_port:
                     type: string
@@ -7364,6 +7469,10 @@ spec:
                     type: boolean
                   data_stream_ilm_name:
                     type: string
+                  data_stream_ilm_policy:
+                    type: string
+                  data_stream_ilm_policy_overwrite:
+                    type: boolean
                   data_stream_name:
                     type: string
                   data_stream_template_name:
@@ -7375,6 +7484,8 @@ spec:
                   enable_ilm:
                     type: boolean
                   exception_backup:
+                    type: boolean
+                  fail_on_detecting_es_version_retry_exceed:
                     type: boolean
                   fail_on_putting_template_retry_exceed:
                     type: boolean
@@ -7490,6 +7601,8 @@ spec:
                   routing_key:
                     type: string
                   scheme:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sniffer_class_name:
                     type: string
@@ -7675,6 +7788,8 @@ spec:
                     type: string
                   recompress:
                     type: boolean
+                  slow_flush_log_threshold:
+                    type: string
                   symlink_path:
                     type: boolean
                 required:
@@ -7911,6 +8026,8 @@ spec:
                       - host
                       type: object
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -8223,6 +8340,8 @@ spec:
                     type: string
                   project:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   storage_class:
                     type: string
                   store_as:
@@ -8435,6 +8554,8 @@ spec:
                     items:
                       type: integer
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   ssl_timeout:
                     type: integer
                   tls_ca_cert_path:
@@ -8702,6 +8823,39 @@ spec:
                     type: integer
                   kafka_agg_max_messages:
                     type: integer
+                  keytab:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
                   max_send_retries:
                     type: integer
                   message_key_key:
@@ -8743,11 +8897,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  principal:
+                    type: string
                   required_acks:
                     type: integer
                   sasl_over_ssl:
                     type: boolean
                   scram_mechanism:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
                     properties:
@@ -9150,6 +9308,8 @@ spec:
                     type: boolean
                   retries_on_batch_request:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   stream_name:
                     type: string
                 required:
@@ -9237,6 +9397,8 @@ spec:
                   ingester_endpoint:
                     type: string
                   request_timeout:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   tags:
                     type: string
@@ -9373,6 +9535,8 @@ spec:
                     type: integer
                   retry_sleep:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                 required:
                 - endpoint
                 type: object
@@ -9601,6 +9765,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  slow_flush_log_threshold:
+                    type: string
                   tenant:
                     type: string
                   url:
@@ -10048,6 +10214,8 @@ spec:
                     type: string
                   selector_class_name:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sniffer_class_name:
                     type: string
                   ssl_verify:
@@ -10314,6 +10482,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   store_as:
                     type: string
                   upload_crc_enable:
@@ -10457,6 +10627,8 @@ spec:
                     type: object
                   port:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   strftime_format:
                     type: string
                   ttl:
@@ -10718,6 +10890,8 @@ spec:
                         type: string
                     type: object
                   signature_version:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   sse_customer_algorithm:
                     type: string
@@ -11035,6 +11209,8 @@ spec:
                     type: string
                   read_timeout:
                     type: integer
+                  slow_flush_log_threshold:
+                    type: string
                   source:
                     type: string
                   source_key:
@@ -11198,6 +11374,8 @@ spec:
                     type: string
                   region:
                     type: string
+                  slow_flush_log_threshold:
+                    type: string
                   sqs_url:
                     type: string
                   tag_property_name:
@@ -11334,6 +11512,8 @@ spec:
                   open_timeout:
                     type: integer
                   proxy_uri:
+                    type: string
+                  slow_flush_log_threshold:
                     type: string
                   source_category:
                     type: string
@@ -11562,6 +11742,8 @@ spec:
                             type: object
                         type: object
                     type: object
+                  slow_flush_log_threshold:
+                    type: string
                   transport:
                     type: string
                   trusted_ca_path:

--- a/katalog/logging-operator/deploy.yaml
+++ b/katalog/logging-operator/deploy.yaml
@@ -11,9 +11,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.7
+    helm.sh/chart: logging-operator-3.17.10
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: logging-operator/templates/clusterrole.yaml
@@ -339,9 +339,9 @@ metadata:
   name: logging-operator
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.7
+    helm.sh/chart: logging-operator-3.17.10
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.10"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -360,7 +360,7 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.7
+    helm.sh/chart: logging-operator-3.17.10
     app.kubernetes.io/instance: logging-operator
 spec:
   type: ClusterIP
@@ -382,9 +382,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-3.17.7
+    helm.sh/chart: logging-operator-3.17.10
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "3.17.7"
+    app.kubernetes.io/version: "3.17.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/katalog/logging-operator/kustomization.yaml
+++ b/katalog/logging-operator/kustomization.yaml
@@ -16,5 +16,5 @@ resources:
 images:
   - name: ghcr.io/banzaicloud/logging-operator
     newName: registry.sighup.io/fury/banzaicloud/logging-operator
-    newTag: 3.17.7
+    newTag: 3.17.10
 


### PR DESCRIPTION
e2e is failing on opensearch, I already tested logging operator on a 1.25 cluster