### PR TITLE
Feat: update opensearch and opensearch dashboards to the latest stable version test it with k8s 1.25

### DIFF
--- a/katalog/logging-operated/minio/sts.yaml
+++ b/katalog/logging-operated/minio/sts.yaml
@@ -52,6 +52,9 @@ spec:
         envFrom:
         - secretRef:
             name: minio-credentials
+        env:
+        - name: MINIO_CONSOLE_ADDRESS
+          value: ":9001"
         image: minio/minio
         securityContext:
           allowPrivilegeEscalation: false
@@ -60,6 +63,7 @@ spec:
         - /data
         ports:
         - containerPort: 9000
+        - containerPort: 9001
         volumeMounts:
         - name: data
           mountPath: /data

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -10,7 +10,7 @@ Alternatively you can download the chart with:
 
 ```bash
 helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm pull opensearch/opensearch-dashboards --version 2.0.1 --untar --untardir /tmp # this command will download the chart in /tmp/opensearch-dashboards
+helm pull opensearch/opensearch-dashboards --version 2.8.0 --untar --untardir /tmp # this command will download the chart in /tmp/opensearch-dashboards
 ```
 
 Run the following command:

--- a/katalog/opensearch-dashboards/README.md
+++ b/katalog/opensearch-dashboards/README.md
@@ -9,12 +9,12 @@ stored in OpenSearch indices.
 
 ## Requirements
 
-- Kubernetes >= `1.20.0`
-- Kustomize >= `v3.3.X`
+- Kubernetes >= `1.23.0`
+- Kustomize = `v3.5.3`
 
 ## Image repository and tag
 
-* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:1.2.0`
+* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:2.5.0`
 * OpenSearch Dashboards repo: [OpenSearch Dashboards on Github][opensearch-dashboards-github]
 * OpenSearch Dashboards documentation: [OpenSearch Dashboards at opensearch.org][opensearch-dashboards-doc]
 

--- a/katalog/opensearch-dashboards/deploy.yaml
+++ b/katalog/opensearch-dashboards/deploy.yaml
@@ -84,6 +84,30 @@ spec:
           runAsUser: 1000
         image: "opensearchproject/opensearch-dashboards"
         imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 10
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          successThreshold: 1
+          tcpSocket:
+            port: 5601
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 10
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          successThreshold: 1
+          tcpSocket:
+            port: 5601
+          timeoutSeconds: 5
+        startupProbe:
+          failureThreshold: 20
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          tcpSocket:
+            port: 5601
+          timeoutSeconds: 5
         command:
           - sh
           - -c
@@ -111,9 +135,6 @@ spec:
           - name: opensearch-dashboards
             mountPath: /usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
             subPath: opensearch_dashboards.yml
-        readinessProbe:
-          tcpSocket:
-            port: 5601
       volumes:
         - name: opensearch-dashboards
           secret:

--- a/katalog/opensearch-dashboards/kustomization.yaml
+++ b/katalog/opensearch-dashboards/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: logging
 images:
   - name: opensearchproject/opensearch-dashboards
     newName: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "2.0.0"
+    newTag: "2.5.0"
 
 resources:
   - deploy.yaml

--- a/katalog/opensearch-single/MAINTENANCE.md
+++ b/katalog/opensearch-single/MAINTENANCE.md
@@ -10,7 +10,7 @@ Alternatively you can download the chart with:
 
 ```bash
 helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-helm pull opensearch/opensearch --version 2.0.1 --untar --untardir /tmp # this command will download the chart in /tmp/opensearch
+helm pull opensearch/opensearch --version 2.10.0 --untar --untardir /tmp # this command will download the chart in /tmp/opensearch
 ```
 
 Run the following command:

--- a/katalog/opensearch-single/README.md
+++ b/katalog/opensearch-single/README.md
@@ -10,8 +10,8 @@ Kubernetes.
 
 ## Requirements
 
-- Kubernetes >= `1.20.0`
-- Kustomize >= `v3.3.X`
+- Kubernetes >= `1.23.0`
+- Kustomize = `v3.5.3`
 - [prometheus-operator][prometheus-operator]
 
 > Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
@@ -19,7 +19,7 @@ Kubernetes.
 
 ## Image repository and tag
 
-* OpenSearch image: `opensearchproject/opensearch:1.2.4`
+* OpenSearch image: `opensearchproject/opensearch:2.5.0`
 * OpenSearch repo: [OpenSearch on Github][opensearch-gh]
 * OpenSearch documentation: [OpenSearch Homepage][opensearch-doc]
 

--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -4,7 +4,7 @@
 
 ---
 # Source: opensearch/templates/poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "opensearch-cluster-master-pdb"
@@ -167,8 +167,22 @@ spec:
             - ALL
           runAsNonRoot: true
           runAsUser: 1000
+          runAsGroup: 1000
         image: "opensearchproject/opensearch"
         imagePullPolicy: "IfNotPresent"
+        readinessProbe:
+          failureThreshold: 3
+          periodSeconds: 5
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 9200
+          timeoutSeconds: 3
         ports:
         - name: http
           containerPort: 9200
@@ -196,6 +210,10 @@ spec:
           value: "0.0.0.0"
         - name: OPENSEARCH_JAVA_OPTS
           value: "-Xms2G -Xmx2G"
+        - name: DISABLE_INSTALL_DEMO_CONFIG
+          value: "true"
+        - name: DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI
+          value: "true"
         - name: node.roles
           value: "master,ingest,data,remote_cluster_client,"
         volumeMounts:

--- a/katalog/opensearch-single/kustomization.yaml
+++ b/katalog/opensearch-single/kustomization.yaml
@@ -14,10 +14,10 @@ images:
     newTag: "1.1.0"
   - name: opensearchproject/opensearch
     newName: registry.sighup.io/fury/opensearchproject/opensearch
-    newTag: "2.0.0"
+    newTag: "2.5.0"
   - name: opensearchproject/opensearch-dashboards
     newName: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "2.0.0"
+    newTag: "2.5.0"
   - name: alpine
     newName: registry.sighup.io/fury/alpine
     newTag: "3.14"


### PR DESCRIPTION
As per title this PR updates opensearch and opensearch dashboards to 2.5.0 version.

Also, I included a little fix on the minio console port (found while testing)