### PR TITLE
Feat: improve @ERROR handling

### DIFF
--- a/katalog/configs/audit/output.yml
+++ b/katalog/configs/audit/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: audit-index-template
           key: audit-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/events/output.yml
+++ b/katalog/configs/events/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: events-index-template
           key: events-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/ingress-nginx/output.yml
+++ b/katalog/configs/ingress-nginx/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: ingress-controller-index-template
           key: ingress-controller-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/kubernetes/cluster-flow.yml
+++ b/katalog/configs/kubernetes/cluster-flow.yml
@@ -19,6 +19,7 @@ spec:
           type: json
         remove_key_name_field: true
         reserve_data: true
+        emit_invalid_record_to_error: false
   match:
     - exclude:
         namespaces:

--- a/katalog/configs/kubernetes/cluster-output.yml
+++ b/katalog/configs/kubernetes/cluster-output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: kubernetes-index-template
           key: kubernetes-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/systemd/etcd/output.yml
+++ b/katalog/configs/systemd/etcd/output.yml
@@ -15,6 +15,7 @@ spec:
     logstash_format: true
     logstash_prefix: systemd
     request_timeout: 600s
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -10,6 +10,7 @@ metadata:
 spec:
   errorOutputRef: errors
   fluentd:
+    logLevel: debug
     image:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
       tag: v1.14.6-alpine-5


### PR DESCRIPTION
This PR improves how we manage `@ERROR` logs. 

First change is to enable the opensearch outputs to log 400 errors with log_os_400_reason: true

The second change is to suppress the parse error when the log is not in JSON format on kubernetes flow (this was sent to `@ERROR` but is not a real error

The third change is to set logLevel: debug on fluentd, to enable emitting 400 errors as @ERROR , see: https://github.com/fluent/fluent-plugin-opensearch#log_os_400_reason 

I was not able to have fluentd logs on stdout, maybe there is a bug, but this change will reduce massively the @ERROR to the minio instances.