### PR TITLE
Hotfix - update release3.0 with hotfixes and enhancement, version 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     Kubernetes Fury Logging
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.0.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v3.0.2-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-logging?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -22,6 +22,7 @@
 | v2.0.2                              |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |                    |
 | v3.0.0                              |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning:          |
 | v3.0.1                              |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.0.2                              |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 
 - :white_check_mark: Compatible

--- a/docs/releases/v3.0.2.md
+++ b/docs/releases/v3.0.2.md
@@ -1,0 +1,33 @@
+# Logging Core Module Release 3.0.2
+
+Welcome to the latest release of `logging` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution)
+maintained by team SIGHUP.
+
+This is a patch release that adds some enhancements and fixes.
+
+## Component Images 🚢
+
+| Component                | Supported Version                                                                                      | Previous Version |
+|--------------------------|--------------------------------------------------------------------------------------------------------|------------------|
+| `opensearch`             | [`v2.0.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/2.0.0)                        | `No update`      |
+| `opensearch-dashboards`  | [`v2.0.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/2.0.0)             | `No update`      |
+| `cerebro`                | [`v0.9.4`](https://github.com/lmenezes/cerebro/releases/tag/v0.9.4)                                    | `No update`      |
+| `logging-operator`       | [`v3.17.7`](https://github.com/banzaicloud/logging-operator/releases/tag/3.17.7)                       | `No update`      |
+| `loki-stack`             | [`v2.4.2`](https://github.com/grafana/loki/releases/tag/v2.4.2)                                        | `No update`      |
+
+## Bug Fixes and Changes 🐛
+
+- Changed the Fluentd log level to debug and enabled `log_os_400_reason: true` on all OpenSearch outputs so that rejected logs from OpenSearch are labeled @ERROR and captured on Minio.
+- Added a retention of 7 days for saved objects on Minio.
+- Removed the emission of @ERROR logs that cannot be parsed in JSON from ClusterFlow Kubernetes.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f -
+```
+

--- a/docs/releases/v3.0.2.md
+++ b/docs/releases/v3.0.2.md
@@ -19,7 +19,7 @@ This is a patch release that adds some enhancements and fixes.
 
 - Changed the Fluentd log level to debug and enabled `log_os_400_reason: true` on all OpenSearch outputs so that rejected logs from OpenSearch are labeled @ERROR and captured on Minio.
 - Added a retention of 7 days for saved objects on Minio.
-- Removed the emission of @ERROR logs that cannot be parsed in JSON from ClusterFlow Kubernetes.
+- Removed the emission of `@ERROR` logs that cannot be parsed in JSON from ClusterFlow Kubernetes.
 
 ## Update Guide 🦮
 

--- a/docs/releases/v3.0.2.md
+++ b/docs/releases/v3.0.2.md
@@ -1,7 +1,6 @@
 # Logging Core Module Release 3.0.2
 
-Welcome to the latest release of `logging` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution)
-maintained by team SIGHUP.
+Welcome to the latest release of `logging` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
 This is a patch release that adds some enhancements and fixes.
 

--- a/katalog/configs/audit/audit-index-template.json
+++ b/katalog/configs/audit/audit-index-template.json
@@ -2,7 +2,7 @@
   "index_patterns" : ["audit-*"],
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "auto_expand_replicas": "0-1",
     "codec": "best_compression"
   }
 }

--- a/katalog/configs/audit/output.yml
+++ b/katalog/configs/audit/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: audit-index-template
           key: audit-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/events/events-index-template.json
+++ b/katalog/configs/events/events-index-template.json
@@ -2,7 +2,7 @@
   "index_patterns" : ["events-*"],
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "auto_expand_replicas": "0-1",
     "codec": "best_compression"
   }
 }

--- a/katalog/configs/events/output.yml
+++ b/katalog/configs/events/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: events-index-template
           key: events-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/ingress-nginx/flow.yml
+++ b/katalog/configs/ingress-nginx/flow.yml
@@ -13,9 +13,23 @@ spec:
         de_dot_separator: "_"
         de_dot_nested: true
     - parser:
-        remove_key_name_field: true
+        key_name: message
         parse:
-          type: nginx
+          type: multi_format
+          patterns:
+            # this is the nginx access log format from the ingress controller
+            - format: regexp
+              expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ,]*(?:,\s[^ ,]*)*) (?<upstream_response_length>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<upstream_response_time>(?:[\d.]+|-)(?:,\s(?:[\d.]+|-))*) (?<upstream_status>(?:\d+|-)(?:,\s(?:\d+|-))*) (?<req_id>[[:alnum:]]*)/'
+              time_format: "%Y-%m-%dT%H:%M:%S.%L%z"
+              types: 'request_length:integer,request_time:float,status:integer,body_bytes_sent:integer,upstream_response_length:string,upstream_response_time:string,upstream_status:string'
+            # this handles nginx error log
+            - format: regexp
+              expression: '/^(?<logtime>\d{4}\/\d{1,2}\/\d{1,2} \d{1,2}:\d{1,2}:\d{1,2}) (?<log_level>\[[^\s]+\]) (?<message>.*)$/'
+              types: 'logtime:string,log_level:string,message:string'
+            # catch all ingress nginx logs
+            - format: regexp
+              expression: '/^(?<generic>.*)$/'
+              types: 'generic:string'
   match:
     - select:
         labels:
@@ -30,14 +44,3 @@ spec:
           type: internal
   localOutputRefs:
     - ingress-nginx
-
-# Alternatively if you want more control over the parsing, you can use the parser below:
-#    - parser:
-#        key_name: log
-#        remove_key_name_field: true
-#        reserve_data: true
-#        parse:
-#          type: regexp
-#          expression: '/^(?<remote_addr>[^ ]*) - (?<remote_user>[^ ]+) \[(?<time_local>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<status>\d+) (?<body_bytes_sent>\d+) "(?<http_referer>[^ ]*)" "(?<http_user_agent>[^\"]*)" (?<request_length>\d+) (?<request_time>[\d.]+) \[(?<proxy_upstream_name>[^\]]*)\] \[(?<proxy_alternative_upstream_name>[^\]]*)\] (?<upstream_addr>[^ ]*) (?<upstream_response_length>\d+|-) (?<upstream_response_time>[\d.]+|-) (?<upstream_status>\d+|-) (?<req_id>[^ ]*)/'
-#          time_key: time
-#          time_format: '%d/%b/%Y:%H:%M:%S %z'

--- a/katalog/configs/ingress-nginx/ingress-controller-index-template.json
+++ b/katalog/configs/ingress-nginx/ingress-controller-index-template.json
@@ -2,7 +2,7 @@
   "index_patterns" : ["ingress-controller-*"],
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "auto_expand_replicas": "0-1",
     "codec": "best_compression"
   }
 }

--- a/katalog/configs/ingress-nginx/output.yml
+++ b/katalog/configs/ingress-nginx/output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: ingress-controller-index-template
           key: ingress-controller-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/kubernetes/cluster-flow.yml
+++ b/katalog/configs/kubernetes/cluster-flow.yml
@@ -19,6 +19,7 @@ spec:
           type: json
         remove_key_name_field: true
         reserve_data: true
+        emit_invalid_record_to_error: false
   match:
     - exclude:
         namespaces:

--- a/katalog/configs/kubernetes/cluster-output.yml
+++ b/katalog/configs/kubernetes/cluster-output.yml
@@ -22,6 +22,7 @@ spec:
         secretKeyRef:
           name: kubernetes-index-template
           key: kubernetes-index-template
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/configs/kubernetes/kubernetes-index-template.json
+++ b/katalog/configs/kubernetes/kubernetes-index-template.json
@@ -2,7 +2,7 @@
   "index_patterns" : ["kubernetes-*"],
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "auto_expand_replicas": "0-1",
     "codec": "best_compression"
   }
 }

--- a/katalog/configs/systemd/common/systemd-index-template.json
+++ b/katalog/configs/systemd/common/systemd-index-template.json
@@ -2,7 +2,7 @@
   "index_patterns" : ["systemd-*"],
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 1,
+    "auto_expand_replicas": "0-1",
     "codec": "best_compression"
   }
 }

--- a/katalog/configs/systemd/etcd/output.yml
+++ b/katalog/configs/systemd/etcd/output.yml
@@ -15,6 +15,7 @@ spec:
     logstash_format: true
     logstash_prefix: systemd
     request_timeout: 600s
+    log_os_400_reason: true
     ssl_verify: false
     suppress_type_name: true
     buffer:

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -10,6 +10,7 @@ metadata:
 spec:
   errorOutputRef: errors
   fluentd:
+    logLevel: debug
     image:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
       tag: v1.14.6-alpine-5

--- a/katalog/logging-operated/minio/cronjob.yaml
+++ b/katalog/logging-operated/minio/cronjob.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-ilm
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: mc-ilm
+              command: 
+               - sh 
+               - -c
+              args: 
+               - | 
+                # Set alias for the two minio instances
+                mc alias set minio_0 http://minio-0.minio.logging.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+                mc alias set minio_1 http://minio-1.minio.logging.svc.cluster.local:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+                
+                # Check connection
+                mc admin info minio_0
+                mc admin info minio_1
+                
+                # Remove all rules (we only need the one that expires objects)
+                mc ilm rm --all --force minio_0/logging
+                mc ilm rm --all --force minio_1/logging
+
+                # Add 7 days rule to each minio instance
+                mc ilm add --expiry-days "7" minio_0/logging
+                mc ilm add --expiry-days "7" minio_1/logging
+
+              envFrom:
+              - secretRef:
+                  name: minio-credentials
+              image: minio/mc
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                allowPrivilegeEscalation: false
+          restartPolicy: OnFailure
+  schedule: "0 * * * *"

--- a/katalog/logging-operated/minio/kustomization.yaml
+++ b/katalog/logging-operated/minio/kustomization.yaml
@@ -10,13 +10,17 @@ resources:
   - rbac.yaml
   - service.yaml
   - sts.yaml
+  - cronjob.yaml
 
 namespace: logging
 
 images:
   - name: minio/minio
     newName: registry.sighup.io/fury/minio
-    newTag: RELEASE.2021-05-26T00-22-46Z
+    newTag: RELEASE.2022-10-24T18-35-07Z
+  - name: minio/mc
+    newName: registry.sighup.io/fury/minio/mc
+    newTag: RELEASE.2022-10-22T03-39-29Z
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/katalog/logging-operated/minio/sts.yaml
+++ b/katalog/logging-operated/minio/sts.yaml
@@ -52,6 +52,9 @@ spec:
         envFrom:
         - secretRef:
             name: minio-credentials
+        env:
+        - name: MINIO_CONSOLE_ADDRESS
+          value: ":9001"
         image: minio/minio
         securityContext:
           allowPrivilegeEscalation: false
@@ -60,6 +63,7 @@ spec:
         - /data
         ports:
         - containerPort: 9000
+        - containerPort: 9001
         volumeMounts:
         - name: data
           mountPath: /data


### PR DESCRIPTION
This PR address these features/hotfixes

- Changed the Fluentd log level to debug and enabled `log_os_400_reason: true` on all OpenSearch outputs so that rejected logs from OpenSearch are labeled @ERROR and captured on Minio.
- Added a retention of 7 days for saved objects on Minio.
- Removed the emission of `@ERROR` logs that cannot be parsed in JSON from ClusterFlow Kubernetes.

Everything was taken from the current main iteration and adapted for the 3.0.x 