### PR TITLE
feat: put dashboards in "Logging" grafana folder

### DIFF
--- a/katalog/logging-operated/dashboards/kustomization.yaml
+++ b/katalog/logging-operated/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: logging
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Logging"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/loki-distributed/datasource/kustomization.yaml
+++ b/katalog/loki-distributed/datasource/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: logging
 generatorOptions:
   labels:
     grafana-sighup-datasource: default
+  annotations:
+    grafana-folder: "Logging"
   disableNameSuffixHash: true
 
 secretGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "Logging" folder for better organization.