### PR TITLE
fix(logging-operated): revert fluentd v1.14 + docs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,10 +8,10 @@ type: docker
 
 steps:
   - name: check
-    image: docker.io/library/golang:1.16
+    image: docker.io/library/golang:1.21
     pull: always
     commands:
-      - go get -u github.com/google/addlicense
+      - go install github.com/google/addlicense@v1.1.1
       - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     Kubernetes Fury Logging
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.2.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v3.2.1-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-logging?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -74,19 +74,19 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: logging/cerebro
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/opensearch-single
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/opensearch-dashboards
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/logging-operator
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/logging-operated
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: minio/minio-ha
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/configs
-    version: "v3.2.0"
+    version: "v3.2.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -124,17 +124,17 @@ kustomize build . | kubectl apply -f -
 ```yaml
 bases:
   - name: logging/loki-distributed
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/logging-operator
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/logging-operated
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: minio/minio-ha
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/configs
-    version: "v3.2.0"
+    version: "v3.2.1"
   - name: logging/loki-configs
-    version: "v3.2.0"
+    version: "v3.2.1"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -14,6 +14,7 @@
 | v3.1.2                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v3.1.3                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v3.2.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.2.1                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v3.2.1.md
+++ b/docs/releases/v3.2.1.md
@@ -1,0 +1,34 @@
+# Logging Core Module Release 3.2.1
+
+Welcome to the latest release of the `logging` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This patch release rolls back the version of `fluentd` due to a [bug](https://github.com/opensearch-project/opensearch-ruby/issues/205) whose fix has not been released yet.
+
+## Component Images 🚢
+
+| Component                | Supported Version                                                                                   | Previous Version |
+|--------------------------|-----------------------------------------------------------------------------------------------------|------------------|
+| `opensearch`             | [`v2.7.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/2.7.0)                     | `No update`      |
+| `opensearch-dashboards`  | [`v2.7.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/2.7.0)          | `No update`      |
+| `cerebro`                | [`v0.9.4`](https://github.com/lmenezes/cerebro/releases/tag/v0.9.4)                                 | `No update`      |
+| `logging-operator`       | [`v4.3.0`](https://github.com/kube-logging/logging-operator/releases/tag/4.1.0)                     | `No update`      |
+| `loki-distributed`       | [`v2.8.0`](https://github.com/grafana/loki/releases/tag/v2.8.0)                                     | `No update`      |
+| `minio-ha`               | [`vRELEASE.2023-01-12T02-06-16Z`](https://github.com/minio/minio/tree/RELEASE.2023-01-12T02-06-16Z) | `No update`      |
+
+## Bug Fixes and Changes 🐛
+
+- Rollback `fluentd` to `v1.14.6`
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f -
+```
+
+
+
+

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -13,7 +13,7 @@ spec:
     logLevel: debug
     image:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
-      tag: v1.15-ruby3
+      tag: v1.14.6-alpine-5
     configReloaderImage:
       repository: registry.sighup.io/fury/banzaicloud/config-reloader
       tag: v0.0.5

--- a/katalog/tests/tests.sh
+++ b/katalog/tests/tests.sh
@@ -47,13 +47,13 @@ set -o pipefail
   apply katalog/opensearch-dashboards
 }
 
-@test "wait for apply to settle and dump state to dump.json" {
+@test "wait for apply to settle and dump state to dump.json (1)" {
   info
   max_retry=0
   echo "=====" $max_retry "=====" >&2
   while kubectl get pods --all-namespaces | grep -ie "\(Pending\|Error\|CrashLoop\|ContainerCreating\|PodInitializing\)" >&2
   do
-    [ $max_retry -lt 30 ] || ( kubectl describe all --all-namespaces >&2 && return 1 )
+    [ $max_retry -lt 60 ] || ( kubectl describe all --all-namespaces >&2 && return 1 )
     sleep 10 && echo "# waiting..." $max_retry >&3
     max_retry=$((max_retry+1))
   done
@@ -140,13 +140,13 @@ set -o pipefail
   apply katalog/loki-configs/infra
 }
 
-@test "wait for apply to settle and dump state to dump.json" {
+@test "wait for apply to settle and dump state to dump.json (2)" {
   info
   max_retry=0
   echo "=====" $max_retry "=====" >&2
   while kubectl get pods --all-namespaces | grep -ie "\(Pending\|Error\|CrashLoop\|ContainerCreating\|PodInitializing\)" >&2
   do
-    [ $max_retry -lt 30 ] || ( kubectl describe all --all-namespaces >&2 && return 1 )
+    [ $max_retry -lt 60 ] || ( kubectl describe all --all-namespaces >&2 && return 1 )
     sleep 10 && echo "# waiting..." $max_retry >&3
     max_retry=$((max_retry+1))
   done


### PR DESCRIPTION
Reverted fluentd to v1.14 due to a [bug](https://github.com/opensearch-project/opensearch-ruby/issues/205).