### PR TITLE
feat(loki-distributed): update to chart v0.78.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -33,7 +33,7 @@ platform:
   arch: amd64
 
 steps:
-  - name: lint
+  - name: Lint with Policeman
     image: quay.io/sighup/policeman
     pull: always
     environment:
@@ -50,7 +50,7 @@ steps:
     depends_on:
       - clone
 
-  - name: render
+  - name: Render Manifests
     image: quay.io/sighup/e2e-testing:1.1.0_0.7.0_3.1.1_1.9.4_1.21.12_3.8.7_4.21.1
     pull: always
     depends_on:
@@ -71,10 +71,10 @@ steps:
     image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
-      - render
+      - Render Manifests
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.27.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.29.0
     environment:
       KUBERNETES_MANIFESTS: cerebro.yml
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,9 +2,12 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-name: license
+name: Check License Header Presence
 kind: pipeline
 type: docker
+
+clone:
+  depth: 1
 
 steps:
   - name: check
@@ -15,12 +18,15 @@ steps:
       - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
 
 ---
-name: policeman
+name: Linting
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 depends_on:
-  - license
+  - Check License Header Presence
 
 platform:
   os: linux
@@ -113,12 +119,15 @@ steps:
       KUBERNETES_MANIFESTS: minio-ha.yml
 
 ---
-name: unit-test
+name: Unit Test
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 depends_on:
-  - policeman
+  - Linting
 
 platform:
   os: linux
@@ -137,25 +146,16 @@ steps:
       event:
       - push
 
-#  - name: examples
-#    image: quay.io/sighup/furyctl-bats:v0.2.2_3.2.2
-#    pull: always
-#    depends_on: [clone]
-#    commands:
-#      - bats examples/tests.bats
-#    when:
-#      event:
-#      - push
 ---
-name: e2e-kubernetes-1.25
+name: E2E Tests Kubernetes 1.26
 kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - Linting
 
-node:
-  runner: internal
+clone:
+  depth: 1
 
 platform:
   os: linux
@@ -164,201 +164,75 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
       - refs/heads/main
       - refs/tags/**
 
 steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
     depends_on: [ clone ]
-    settings:
-      action: custom-cluster-125
-      pipeline_id: cluster-125
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.25.3'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_0.9.0_3.1.1_1.9.4_1.25.3_3.5.3_4.21.1
-    pull: always
     volumes:
-      - name: shared
-        path: /shared
-    depends_on: [ init ]
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.26.6
+      KUBECONFIG: kubeconfig-126
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-125
-      - bats -t katalog/tests/tests.sh
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.25.3
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-125
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-    when:
-      status:
-        - success
-        - failure
 
-volumes:
-  - name: shared
-    temp: {}
----
-name: e2e-kubernetes-1.26
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-node:
-  runner: internal
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/master
-      - refs/heads/main
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
-    pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: custom-cluster-126
-      pipeline_id: cluster-126
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.26.4'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
+  - name: End-to-End Tests
     # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
     image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
-    depends_on: [ init ]
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-126
+    depends_on: [ "Create Kind Cluster" ]
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-126
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/tests.sh
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.26.4
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-126
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-126
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
     when:
       status:
         - success
         - failure
 
 volumes:
-  - name: shared
-    temp: {}
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
 
 ---
-name: e2e-kubernetes-1.27
+name: E2E Tests Kubernetes 1.27
 kind: pipeline
 type: docker
 
 depends_on:
-  - policeman
+  - Linting
 
-node:
-  runner: internal
+clone:
+  depth: 1
 
 platform:
   os: linux
@@ -367,97 +241,232 @@ platform:
 trigger:
   ref:
     include:
-      - refs/heads/master
       - refs/heads/main
       - refs/tags/**
 
 steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
     pull: always
-    volumes:
-      - name: shared
-        path: /shared
     depends_on: [ clone ]
-    settings:
-      action: custom-cluster-127
-      pipeline_id: cluster-127
-      local_kind_config_path: katalog/tests/kind/config.yml
-      cluster_version: '1.27.1'
-      instance_path: /shared
-      instance_size: 2-extra-large
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.12.0_1.9.4_1.27.1_3.5.3_4.33.3
-    pull: always
     volumes:
-      - name: shared
-        path: /shared
-    depends_on: [ init ]
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.27.3
+      KUBECONFIG: kubeconfig-127
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
     commands:
-      - export KUBECONFIG=/shared/kube/kubeconfig-127
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-127
+    depends_on: [ "Create Kind Cluster" ]
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
       - bats -t katalog/tests/tests.sh
 
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v1.27.1
-    pull: always
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-127
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-      dockerhub_username:
-        from_secret: dockerhub_username
-      dockerhub_password:
-        from_secret: dockerhub_password
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-127
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
     when:
       status:
         - success
         - failure
 
 volumes:
-  - name: shared
-    temp: {}
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
+---
+name: E2E Tests Kubernetes 1.28
+kind: pipeline
+type: docker
+
+depends_on:
+  - Linting
+
+clone:
+  depth: 1
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on: [ clone ]
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.28.0
+      KUBECONFIG: kubeconfig-128
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-128
+    depends_on: [ "Create Kind Cluster" ]
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/tests.sh
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
+---
+name: E2E Tests Kubernetes 1.29
+kind: pipeline
+type: docker
+
+depends_on:
+  - Linting
+
+clone:
+  depth: 1
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/tags/**
+
+steps:
+  - name: Create Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    pull: always
+    depends_on: [ clone ]
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      KIND_CONFIG: ./katalog/tests/kind/config.yml
+      CLUSTER_VERSION: v1.29.0
+      KUBECONFIG: kubeconfig-129
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config $${KIND_CONFIG}
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+
+  - name: End-to-End Tests
+    # KUBECTL 1.25.3 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.1.1_1.9.4_1.26.3_3.5.3_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      KUBECONFIG: kubeconfig-129
+    depends_on: [ "Create Kind Cluster" ]
+    commands:
+      # wait for Kind cluster to be ready
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t katalog/tests/tests.sh
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-129
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    depends_on:
+      - End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+
 ---
 name: release
 kind: pipeline
 type: docker
 
+clone:
+  depth: 1
+
 depends_on:
-  - e2e-kubernetes-1.25
-  - e2e-kubernetes-1.26
-  - e2e-kubernetes-1.27
+  - E2E Tests Kubernetes 1.26
+  - E2E Tests Kubernetes 1.27
+  - E2E Tests Kubernetes 1.28
+  - E2E Tests Kubernetes 1.29
 
 platform:
   os: linux

--- a/katalog/loki-distributed/MAINTENANCE.md
+++ b/katalog/loki-distributed/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 To maintain the Loki Stack package, you should follow these steps.
 
-Download the latest tgz from [Grafana Helm Charts Loki Stack releseas][github-releases].
+Download the latest tgz for `loki-distributed` from [Grafana Helm Charts Loki Stack releases][github-releases] (there are other charts in the releases page).
 
 Extract to a folder of your choice, for example: `/tmp/loki-distributed`.
 
@@ -24,9 +24,8 @@ With the `loki-stack-built.yaml` file, check differences with the current `deplo
 
 What was customized (what differs from the helm template command):
 
-- Loki configuration has been moved on it's own file `configs/loki.yaml`
-- Gateway service has been renamed as loki-stack to maintain compatibility with existing loki-configs
+- Loki configuration has been moved on it's own file `configs/config.yaml`
+- Gateway service has been renamed from `loki-distributed-gateway` to `loki-stack` to maintain compatibility with existing loki-configs
 - Configmap loki-distributed has been changed to a secret
-
 
 [github-releases]: https://github.com/grafana/helm-charts/releases?q=loki-stack&expanded=true

--- a/katalog/loki-distributed/MAINTENANCE.values.yaml
+++ b/katalog/loki-distributed/MAINTENANCE.values.yaml
@@ -3,7 +3,6 @@
 # license that can be found in the LICENSE file.
 
 ---
-
 loki:
   schemaConfig:
     configs:
@@ -67,6 +66,14 @@ ingester:
     storageClass: null
     # -- Annotations for ingester PVCs
     annotations: {}
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the distributor
 distributor:
@@ -83,6 +90,14 @@ distributor:
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the distributor
     targetMemoryUtilizationPercentage:
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the querier
 querier:
@@ -117,6 +132,14 @@ querier:
   appProtocol:
     # -- Set the optional grpc service protocol. Ex: "grpc", "http2" or "https"
     grpc: ""
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the query-frontend
 queryFrontend:
@@ -133,6 +156,14 @@ queryFrontend:
     targetCPUUtilizationPercentage: 60
     # -- Target memory utilisation percentage for the query-frontend
     targetMemoryUtilizationPercentage:
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the gateway
 gateway:
@@ -158,11 +189,23 @@ gateway:
     targetMemoryUtilizationPercentage:
   # -- See `kubectl explain deployment.spec.strategy` for more,
   # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the compactor
 compactor:
   # -- Specifies whether compactor should be enabled
   enabled: true
+
+  # -- Default has changed from Deployment to StatefulSet in 0.78.0, we keep it as deployment
+  # ref: https://github.com/grafana/helm-charts/pull/2747
+  kind: Deployment
 
   persistence:
     # -- Enable creating PVCs for the compactor
@@ -177,6 +220,14 @@ compactor:
     storageClass: null
     # -- Annotations for compactor PVCs
     annotations: {}
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi
 
 # Configuration for the ruler
 ruler:
@@ -200,3 +251,11 @@ ruler:
     # -- Annotations for ruler PVCs
     annotations: {}
   # -- Directories containing rules files
+  # -- Setting resources and limits
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1024Mi

--- a/katalog/loki-distributed/README.md
+++ b/katalog/loki-distributed/README.md
@@ -9,7 +9,7 @@ It does not index the contents of the logs, but rather a set of labels for each 
 ## Requirements
 
 - Kubernetes >= `1.24.0`
-- Kustomize >= `v3.5.3`
+- Kustomize >= `v3.10.0`
 - [prometheus-operator from KFD monitoring module][prometheus-operator]
 - [grafana from KFD monitoring module][grafana] (module version `>=1.15.0`)
 - [minio-ha](../minio-ha)
@@ -19,8 +19,8 @@ It does not index the contents of the logs, but rather a set of labels for each 
 
 ## Image repository and tag
 
-* Loki image: `grafana/loki`
-* Loki repo: [Loki on Github][loki-gh]
+- Loki image: `grafana/loki`
+- Loki repo: [Loki on Github][loki-gh]
 
 ## Configuration
 
@@ -29,15 +29,16 @@ Loki Distributed is deployed in the following configuration:
 - Each microservice has its own Deployment/StatefulSet
 - Each Deployment has its own HPA
 - Common resources set as:
-    ```yaml
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 1024Mi
-    ```
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 1024Mi
+```
 
 ## Deployment
 

--- a/katalog/loki-distributed/deploy.yml
+++ b/katalog/loki-distributed/deploy.yml
@@ -9,7 +9,7 @@ kind: ServiceAccount
 metadata:
   name: loki-distributed
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -22,7 +22,7 @@ kind: ConfigMap
 metadata:
   name: loki-distributed-gateway
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -34,45 +34,45 @@ data:
     error_log  /dev/stderr;
     pid        /tmp/nginx.pid;
     worker_rlimit_nofile 8192;
-
+    
     events {
       worker_connections  4096;  ## Default: 1024
     }
-
+    
     http {
       client_body_temp_path /tmp/client_temp;
       proxy_temp_path       /tmp/proxy_temp_path;
       fastcgi_temp_path     /tmp/fastcgi_temp;
       uwsgi_temp_path       /tmp/uwsgi_temp;
       scgi_temp_path        /tmp/scgi_temp;
-
+    
       proxy_http_version    1.1;
-
+    
       default_type application/octet-stream;
       log_format   main '$remote_addr - $remote_user [$time_local]  $status '
             '"$request" $body_bytes_sent "$http_referer" '
             '"$http_user_agent" "$http_x_forwarded_for"';
       access_log   /dev/stderr  main;
-
+    
       sendfile     on;
       tcp_nopush   on;
       resolver kube-dns.kube-system.svc.cluster.local;
-
+    
       server {
         listen             8080;
-
+    
         location = / {
           return 200 'OK';
           auth_basic off;
           access_log off;
         }
-
+    
         location = /api/prom/push {
           set $api_prom_push_backend http://loki-distributed-distributor.logging.svc.cluster.local;
           proxy_pass       $api_prom_push_backend:3100$request_uri;
           proxy_http_version 1.1;
         }
-
+    
         location = /api/prom/tail {
           set $api_prom_tail_backend http://loki-distributed-querier.logging.svc.cluster.local;
           proxy_pass       $api_prom_tail_backend:3100$request_uri;
@@ -80,7 +80,7 @@ data:
           proxy_set_header Connection "upgrade";
           proxy_http_version 1.1;
         }
-
+    
         # Ruler
         location ~ /prometheus/api/v1/alerts.* {
           proxy_pass       http://loki-distributed-ruler.logging.svc.cluster.local:3100$request_uri;
@@ -94,19 +94,19 @@ data:
         location ~ /api/prom/alerts.* {
           proxy_pass       http://loki-distributed-ruler.logging.svc.cluster.local:3100$request_uri;
         }
-
+    
         location ~ /api/prom/.* {
           set $api_prom_backend http://loki-distributed-query-frontend-headless.logging.svc.cluster.local;
           proxy_pass       $api_prom_backend:3100$request_uri;
           proxy_http_version 1.1;
         }
-
+    
         location = /loki/api/v1/push {
           set $loki_api_v1_push_backend http://loki-distributed-distributor.logging.svc.cluster.local;
           proxy_pass       $loki_api_v1_push_backend:3100$request_uri;
           proxy_http_version 1.1;
         }
-
+    
         location = /loki/api/v1/tail {
           set $loki_api_v1_tail_backend http://loki-distributed-querier.logging.svc.cluster.local;
           proxy_pass       $loki_api_v1_tail_backend:3100$request_uri;
@@ -114,7 +114,7 @@ data:
           proxy_set_header Connection "upgrade";
           proxy_http_version 1.1;
         }
-
+    
         location ~ /loki/api/.* {
           set $loki_api_backend http://loki-distributed-query-frontend-headless.logging.svc.cluster.local;
           proxy_pass       $loki_api_backend:3100$request_uri;
@@ -129,14 +129,14 @@ kind: ConfigMap
 metadata:
   name: loki-distributed-runtime
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
     app.kubernetes.io/managed-by: Helm
 data:
   runtime.yaml: |
-
+    
     {}
 ---
 # Source: loki-distributed/templates/compactor/persistentvolumeclaim-compactor.yaml
@@ -164,7 +164,7 @@ kind: Service
 metadata:
   name: loki-distributed-compactor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -192,7 +192,7 @@ kind: Service
 metadata:
   name: loki-distributed-distributor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -220,7 +220,7 @@ kind: Service
 metadata:
   name: loki-stack
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -271,7 +271,7 @@ kind: Service
 metadata:
   name: loki-distributed-ingester
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -326,7 +326,7 @@ kind: Service
 metadata:
   name: loki-distributed-querier
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -354,7 +354,7 @@ kind: Service
 metadata:
   name: loki-distributed-query-frontend-headless
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -389,7 +389,7 @@ kind: Service
 metadata:
   name: loki-distributed-query-frontend
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -422,7 +422,7 @@ kind: Service
 metadata:
   name: loki-distributed-memberlist
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -568,7 +568,7 @@ kind: Deployment
 metadata:
   name: loki-distributed-distributor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -597,7 +597,7 @@ spec:
         app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: loki-distributed
-
+      
       securityContext:
         fsGroup: 10001
         runAsGroup: 10001
@@ -625,7 +625,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
             httpGet:
@@ -644,12 +644,12 @@ spec:
             - name: runtime-config
               mountPath: /var/loki-distributed-runtime
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
             limits:
               cpu: 500m
               memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -668,7 +668,7 @@ spec:
                     app.kubernetes.io/instance: loki-distributed
                     app.kubernetes.io/component: distributor
                 topologyKey: failure-domain.beta.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           secret:
@@ -683,7 +683,7 @@ kind: Deployment
 metadata:
   name: loki-distributed-gateway
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -708,7 +708,7 @@ spec:
         app.kubernetes.io/component: gateway
     spec:
       serviceAccountName: loki-distributed
-
+      
       securityContext:
         fsGroup: 101
         runAsGroup: 101
@@ -738,7 +738,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             readOnlyRootFilesystem: true
           volumeMounts:
             - name: config
@@ -748,12 +748,12 @@ spec:
             - name: docker-entrypoint-d-override
               mountPath: /docker-entrypoint.d
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
             limits:
               cpu: 500m
               memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -772,7 +772,7 @@ spec:
                     app.kubernetes.io/instance: loki-distributed
                     app.kubernetes.io/component: gateway
                 topologyKey: failure-domain.beta.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           configMap:
@@ -788,7 +788,7 @@ kind: Deployment
 metadata:
   name: loki-distributed-query-frontend
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -813,9 +813,10 @@ spec:
         app.kubernetes.io/name: loki-distributed
         app.kubernetes.io/instance: loki-distributed
         app.kubernetes.io/component: query-frontend
+        app.kubernetes.io/part-of: memberlist
     spec:
       serviceAccountName: loki-distributed
-
+      
       securityContext:
         fsGroup: 10001
         runAsGroup: 10001
@@ -836,11 +837,14 @@ spec:
             - name: grpc
               containerPort: 9095
               protocol: TCP
+            - name: http-memberlist
+              containerPort: 7946
+              protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
             httpGet:
@@ -859,12 +863,12 @@ spec:
             - name: runtime-config
               mountPath: /var/loki-distributed-runtime
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
             limits:
               cpu: 500m
               memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -883,7 +887,7 @@ spec:
                     app.kubernetes.io/instance: loki-distributed
                     app.kubernetes.io/component: query-frontend
                 topologyKey: failure-domain.beta.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           secret:
@@ -898,7 +902,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: loki-distributed-distributor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -925,7 +929,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: loki-distributed-gateway
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -952,7 +956,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: loki-distributed-ingester
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -979,7 +983,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: loki-distributed-query-frontend
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1006,7 +1010,7 @@ kind: StatefulSet
 metadata:
   name: loki-distributed-ingester
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1044,9 +1048,9 @@ spec:
               app.kubernetes.io/name: loki-distributed
               app.kubernetes.io/instance: loki-distributed
               app.kubernetes.io/component: ingester
-
+        
       serviceAccountName: loki-distributed
-
+      
       securityContext:
         fsGroup: 10001
         runAsGroup: 10001
@@ -1074,26 +1078,21 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             readOnlyRootFilesystem: true
+          
           readinessProbe:
             httpGet:
               path: /ready
               port: http
             initialDelaySeconds: 30
             timeoutSeconds: 1
+          
           livenessProbe:
             httpGet:
               path: /ready
               port: http
             initialDelaySeconds: 300
-          resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
-            limits:
-              cpu: 500m
-              memory: 1024Mi
           volumeMounts:
             - name: config
               mountPath: /etc/loki/config
@@ -1101,6 +1100,13 @@ spec:
               mountPath: /var/loki-distributed-runtime
             - name: data
               mountPath: /var/loki
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1119,7 +1125,7 @@ spec:
                     app.kubernetes.io/instance: loki-distributed
                     app.kubernetes.io/component: ingester
                 topologyKey: failure-domain.beta.kubernetes.io/zone
-
+        
       volumes:
         - name: config
           secret:
@@ -1143,7 +1149,7 @@ kind: StatefulSet
 metadata:
   name: loki-distributed-querier
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1182,9 +1188,9 @@ spec:
               app.kubernetes.io/name: loki-distributed
               app.kubernetes.io/instance: loki-distributed
               app.kubernetes.io/component: querier
-
+        
       serviceAccountName: loki-distributed
-
+      
       securityContext:
         fsGroup: 10001
         runAsGroup: 10001
@@ -1212,7 +1218,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - ALL
+              - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
             httpGet:
@@ -1233,12 +1239,12 @@ spec:
             - name: data
               mountPath: /var/loki
           resources:
-            requests:
-              cpu: 100m
-              memory: 128Mi
             limits:
               cpu: 500m
               memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1257,6 +1263,7 @@ spec:
                     app.kubernetes.io/instance: loki-distributed
                     app.kubernetes.io/component: querier
                 topologyKey: failure-domain.beta.kubernetes.io/zone
+        
       volumes:
         - name: config
           secret:
@@ -1280,7 +1287,7 @@ kind: PrometheusRule
 metadata:
   name: loki-distributed
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1295,7 +1302,7 @@ kind: ServiceMonitor
 metadata:
   name: loki-distributed-compactor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1317,7 +1324,7 @@ kind: ServiceMonitor
 metadata:
   name: loki-distributed-distributor
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1339,7 +1346,7 @@ kind: ServiceMonitor
 metadata:
   name: loki-distributed-ingester
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1351,11 +1358,6 @@ spec:
       app.kubernetes.io/name: loki-distributed
       app.kubernetes.io/instance: loki-distributed
       app.kubernetes.io/component: ingester
-    matchExpressions:
-      - key: prometheus.io/service-monitor
-        operator: NotIn
-        values:
-          - "false"
   endpoints:
     - port: http
       scheme: http
@@ -1366,7 +1368,7 @@ kind: ServiceMonitor
 metadata:
   name: loki-distributed-querier
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"
@@ -1378,11 +1380,6 @@ spec:
       app.kubernetes.io/name: loki-distributed
       app.kubernetes.io/instance: loki-distributed
       app.kubernetes.io/component: querier
-    matchExpressions:
-      - key: prometheus.io/service-monitor
-        operator: NotIn
-        values:
-          - "false"
   endpoints:
     - port: http
       scheme: http
@@ -1393,7 +1390,7 @@ kind: ServiceMonitor
 metadata:
   name: loki-distributed-query-frontend
   labels:
-    helm.sh/chart: loki-distributed-0.76.1
+    helm.sh/chart: loki-distributed-0.78.1
     app.kubernetes.io/name: loki-distributed
     app.kubernetes.io/instance: loki-distributed
     app.kubernetes.io/version: "2.9.2"

--- a/katalog/tests/kind/config.yml
+++ b/katalog/tests/kind/config.yml
@@ -1,11 +1,12 @@
-# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  apiServerAddress: "0.0.0.0"
+# we let kind choose a random port for the API server.
+# networking:
+#   apiServerAddress: "0.0.0.0"
 # One control plane node and three "workers".
 #
 # While these will not add more real compute capacity and
@@ -20,12 +21,3 @@ nodes:
 - role: control-plane
 - role: worker
 - role: worker
-
-containerdConfigPatches:
-- |-
-    [debug]
-      level = "debug"
-    [plugins."io.containerd.grpc.v1.cri".registry]
-      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]


### PR DESCRIPTION
- update manifests to align with latest chart version from upstream (v0.78.1).
- update maintenance guide with some more details.
- update maintenance values.yaml file to minimize manual changes.

> [!NOTE]
> `compactor` has been changed to a StatefulSet in v0.78.0 of the Helm Chart but can still be installed as a deployment. I've updated the maintenance values.yaml file to keep the deployment mode for backwards compatbility.

There are no substantial functional changes. Components versions remain the same.

> [!WARNING]
> This PR is branched from https://github.com/sighupio/fury-kubernetes-logging/pull/160

Resolves https://github.com/sighupio/product-management/issues/387