### PR TITLE
fix(logging-operated): add positiondb, enable operator to recreate resources

### DIFF
--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -9,6 +9,7 @@ metadata:
   name: infra
 spec:
   errorOutputRef: errors
+  enableRecreateWorkloadOnImmutableFieldChange: true
   fluentd:
     logLevel: debug
     image:
@@ -80,3 +81,6 @@ spec:
     requests:
       cpu: 100m
       memory: 50M
+  positiondb:
+    hostPath:
+      path: /var/log/infra-fluentbit-pos


### PR DESCRIPTION
This PR includes:

- restore persistent `positiondb`
- add the field `enableRecreateWorkloadOnImmutableFieldChange` as true in order to enable the operator to recreate resources in case there is a change in an immutable field

Tested the upgrade from the previous version with Kubernetes 1.28.