### PR TITLE
chore(opensearch/opensearch-dashboards): add labels for jobtemplate

### DIFF
--- a/katalog/opensearch-dashboards/index-patterns-cronjob.yml
+++ b/katalog/opensearch-dashboards/index-patterns-cronjob.yml
@@ -11,6 +11,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: opensearch-dashboards
+            app.kubernetes.io/instance: opensearch-dashboards
         spec:
           containers:
           - name: index-patterns

--- a/katalog/opensearch-single/ism-policy-cronjob.yml
+++ b/katalog/opensearch-single/ism-policy-cronjob.yml
@@ -11,6 +11,10 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: opensearch
+            app.kubernetes.io/instance: opensearch
         spec:
           containers:
             - name: policy


### PR DESCRIPTION
This PR adds labels for opensearch and opensearch-dashboard cronjob pods that will be needed by Network Policies to manage traffic between pods.