### PR TITLE
feat(opensearch): update es exporter to v1.8.0

### DIFF
--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -223,12 +223,12 @@ spec:
           mountPath: /usr/share/opensearch/config/opensearch.yml
           subPath: opensearch.yml
       - name: exporter
-        image: justwatch/elasticsearch_exporter
+        image: quay.io/prometheuscommunity/elasticsearch-exporter
         args:
           - '--es.uri=http://localhost:9200'
-          - '--es.cluster_settings'
+          - '--collector.clustersettings'
           - '--es.indices'
-          - '--es.snapshots'
+          - '--collector.snapshots'
           - '--web.listen-address=:9108'
         ports:
           - containerPort: 9108

--- a/katalog/opensearch-single/kustomization.yaml
+++ b/katalog/opensearch-single/kustomization.yaml
@@ -9,9 +9,9 @@ kind: Kustomization
 namespace: logging
 
 images:
-  - name: justwatch/elasticsearch_exporter
-    newName: registry.sighup.io/fury/justwatch/elasticsearch_exporter
-    newTag: "1.1.0"
+  - name: quay.io/prometheuscommunity/elasticsearch-exporter
+    newName: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
+    newTag: "v1.8.0"
   - name: opensearchproject/opensearch
     newName: registry.sighup.io/fury/opensearchproject/opensearch
     newTag: "2.17.1"


### PR DESCRIPTION
This PR updates the es search exporter to the v1.8.0 version using the image maintained by the prometheus community. Closes #168 