### PR TITLE
fix(configs/eventtailer): use right tag for image

### DIFF
--- a/katalog/configs/events/kubernetes-eventtailer.yml
+++ b/katalog/configs/events/kubernetes-eventtailer.yml
@@ -10,4 +10,4 @@ metadata:
 spec:
   controlNamespace: logging
   containerOverrides:
-    image: registry.sighup.io/fury/banzaicloud/eventrouter:v0.4.0
+    image: registry.sighup.io/fury/banzaicloud/eventrouter:0.4.0


### PR DESCRIPTION
Since switching to images from kube-logging instead of the ones from Banzai Cloud, upstream image tags don't have the `v` in front anymore:

https://github.com/kube-logging/eventrouter/pkgs/container/eventrouter/118063456?tag=0.4.0
(upstream taken from our image-sync repository)

Ref:
- https://github.com/sighupio/fury-distribution-container-image-sync/pull/191