### PR TITLE
feat: update minio deployment to the latest version same version on all modules

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,42 @@
+# Logging Core Module Release vTBD
+
+Welcome to the latest release of the `logging` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This update is a major version that adds support for the Kubernetes version 1.32.
+
+## Component Images 🚢
+
+| Component               | Supported Version                                                                                   | Previous Version |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `opensearch`            | [`v2.17.1`](https://github.com/opensearch-project/OpenSearch/releases/tag/2.12.0)                   | `2.12.0`         |
+| `opensearch-dashboards` | [`v2.17.1`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/2.12.0)        | `2.12.0`         |
+| `logging-operator`      | [`v4.10.0`](https://github.com/kube-logging/logging-operator/releases/tag/4.10.0)                   | `4.5.6`          |
+| `loki-distributed`      | [`v2.9.10`](https://github.com/grafana/loki/releases/tag/v2.9.10)                                   | `2.9.2`          |
+| `minio-ha`              | [`RELEASE.2025-02-28T09-55-16Z`](https://github.com/minio/minio/tree/RELEASE.2025-02-28T09-55-16Z)  | `RELEASE.2024-10-13T13-34-11Z` |
+
+## Bug Fixes and Changes 🐛
+
+- Added support for Kubernetes version 1.32
+- Updated MinIO to version `RELEASE.2025-02-28T09-55-16Z`
+
+## Breaking Changes 💔
+
+None/TBD
+
+## Update Guide 🦮
+
+⚠ TBD
+
+### Upgrade using the distribution
+
+To upgrade the module using the distribution please refer to the [`official documentation`](https://docs.kubernetesfury.com/docs/upgrades/upgrades)
+
+### Manual Upgrade
+
+ℹ️ **Note:** Manually upgrading the module is deprecated. It is reccommended to use [`fury distribution`](https://github.com/sighupio/fury-distribution)
+
+To upgrade the module run:
+
+```bash
+kustomize build | kubectl apply -f -
+```

--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -2,22 +2,39 @@
 
 To maintain the MinIO package, you should follow these steps.
 
-Download the latest tgz from [Main Minio repository releases](https://github.com/minio/minio/releases).
+1. Take note of the latest chart version from [Main Minio repository releases](https://github.com/minio/minio/releases).
+2. Take note also of the latest pushed version of both [`fury/minio`](https://registry.sighup.io/harbor/projects/37/repositories/minio/artifacts-tab`) and [`fury/minio/mc`](https://registry.sighup.io/harbor/projects/37/repositories/minio%2Fmc/artifacts-tab) images in our Harbor registry
+    - If necessary, add a newer version on our [fury-images](https://github.com/sighupio/fury-images) git repo
 
-Extract to a folder of your choice, for example: `/tmp/minio`.
+3. Run the following commands:
 
-Run the following command:
-
-```bash
-helm template minio-logging /tmp/minio/helm/minio --values MAINTENANCE.values.yaml -n logging > minio-built.yaml
-```
+  ```bash
+  VERSION=5.4.0 # update this to the latest chart version
+  MINIO_TAG="RELEASE.2025-02-28T09-55-16Z" # update this to the latest fury/minio image tag
+  MC_TAG="RELEASE.2025-02-21T16-00-46Z" # update this to the latest fury/minio/mc image tag
+  helm repo add minio https://charts.min.io/
+  helm repo update
+  helm pull minio/minio --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/minio
+  helm template minio-logging /tmp/minio/ --values MAINTENANCE.values.yaml --set "image.tag"="$MINIO_TAG" --set "imageMc.tag"="$MC_TAG" -n logging > minio-built.yaml
+  ```
 
 Minio's helm comes packaged with a specific mc (its client) version, to find out
-which version comes with it you can inspect `/tmp/minio/helm/minio/values.yaml`.
+which version comes with it you can inspect `/tmp/minio/values.yaml`.
 
 What was customized (what differs from the helm template command):
 
-- Config has been moved from the template output and generated via kustomize
+- Secret `minio-logging` is generated from Kustomize, so it must be removed from `minio-built.yaml`
+- ConfigMap `minio-logging` is removed as it was not used
+- Added `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity configuration on the StatefulSet pods
+- Added `cpu: 100m` to the requests of the StatefulSet pods
 - Added a custom init job to create buckets and add 7 day retention
-- Added `preferredDuringSchedulingIgnoredDuringExecution` on minio pods
+- The container images are rewritten with Kustomize, remember to update them
 
+Review the differences between `minio-built.yaml` and `deploy.yaml`, make the customization described above and replace `deploy.yaml` with the contents of `minio-built.yaml`.
+
+Cleanup:
+
+```bash
+rm minio-built.yaml
+rm -rf /tmp/minio
+```

--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -28,7 +28,6 @@ What was customized (what differs from the helm template command):
 - Added `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity configuration on the StatefulSet pods
 - Added `cpu: 100m` to the requests of the StatefulSet pods
 - Added a custom init job to create buckets and add 7 day retention
-- The container images are rewritten with Kustomize, remember to update them
 
 Review the differences between `minio-built.yaml` and `deploy.yaml`, make the customization described above and replace `deploy.yaml` with the contents of `minio-built.yaml`.
 

--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -4,7 +4,7 @@ To maintain the MinIO package, you should follow these steps.
 
 1. Take note of the latest chart version from [Main Minio repository releases](https://github.com/minio/minio/releases).
 2. Take note also of the latest pushed version of both [`fury/minio`](https://registry.sighup.io/harbor/projects/37/repositories/minio/artifacts-tab`) and [`fury/minio/mc`](https://registry.sighup.io/harbor/projects/37/repositories/minio%2Fmc/artifacts-tab) images in our Harbor registry
-    - If necessary, add a newer version on our [fury-images](https://github.com/sighupio/fury-images) git repo
+    - If necessary, add a newer version on our [fury-distribution-container-image-sync](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/dr/images.yml#L102) git repo
 
 3. Run the following commands:
 

--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -25,8 +25,6 @@ What was customized (what differs from the helm template command):
 
 - Secret `minio-logging` is generated from Kustomize, so it must be removed from `minio-built.yaml`
 - ConfigMap `minio-logging` is removed as it was not used
-- Added `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity configuration on the StatefulSet pods
-- Added `cpu: 100m` to the requests of the StatefulSet pods
 - Added a custom init job to create buckets and add 7 day retention
 
 Review the differences between `minio-built.yaml` and `deploy.yaml`, make the customization described above and replace `deploy.yaml` with the contents of `minio-built.yaml`.

--- a/katalog/minio-ha/MAINTENANCE.values.yaml
+++ b/katalog/minio-ha/MAINTENANCE.values.yaml
@@ -38,7 +38,18 @@ ingress:
 consoleIngress:
   enabled: false
 
-affinity: {}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: "release"
+                operator: In
+                values:
+                  - minio-logging
+          topologyKey: "kubernetes.io/hostname"
 topologySpreadConstraints: []
 
 ## Add stateful containers to have security context, if enabled MinIO will run as this
@@ -61,6 +72,7 @@ podLabels: {}
 ##
 resources:
   requests:
+    cpu: 100m
     memory: 512Mi
 
 ## List of users to be created after minio install

--- a/katalog/minio-ha/deploy.yaml
+++ b/katalog/minio-ha/deploy.yaml
@@ -101,18 +101,6 @@ spec:
         app: minio
         release: minio-logging
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: "release"
-                      operator: In
-                      values:
-                        - minio-logging
-                topologyKey: "kubernetes.io/hostname"
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
@@ -157,6 +145,18 @@ spec:
               memory: 512Mi
           securityContext:
             readOnlyRootFilesystem: false
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: release
+                  operator: In
+                  values:
+                  - minio-logging
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       volumes:
         - name: minio-user
           secret:

--- a/katalog/minio-ha/deploy.yaml
+++ b/katalog/minio-ha/deploy.yaml
@@ -16,7 +16,7 @@ metadata:
   name: minio-logging-console
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
 spec:
@@ -37,7 +37,7 @@ metadata:
   name: minio-logging
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
     monitoring: "true"
@@ -59,7 +59,7 @@ metadata:
   name: minio-logging-svc
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
 spec:
@@ -81,7 +81,7 @@ metadata:
   name: minio-logging
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
 spec:
@@ -121,7 +121,7 @@ spec:
       serviceAccountName: minio-sa
       containers:
         - name: minio
-          image: registry.sighup.io/fury/minio:RELEASE.2024-04-18T19-09-19Z
+          image: registry.sighup.io/fury/minio:RELEASE.2025-02-28T09-55-16Z
           imagePullPolicy: IfNotPresent
           command: [
             "/bin/sh",
@@ -188,7 +188,7 @@ metadata:
   name: minio-logging-cluster
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
 spec:
@@ -209,7 +209,7 @@ metadata:
   name: minio-logging
   labels:
     app: minio
-    chart: minio-5.3.0
+    chart: minio-5.4.0
     release: minio-logging
     heritage: Helm
 spec:

--- a/katalog/minio-ha/kustomization.yaml
+++ b/katalog/minio-ha/kustomization.yaml
@@ -16,10 +16,6 @@ resources:
 images:
   - name: registry.sighup.io/fury/groundnuty/k8s-wait-for
     newTag: v1.6
-  - name: registry.sighup.io/fury/minio/mc
-    newTag: RELEASE.2024-10-08T09-37-26Z
-  - name: registry.sighup.io/fury/minio
-    newTag: RELEASE.2024-10-13T13-34-11Z
 
 secretGenerator:
   - name: minio-logging


### PR DESCRIPTION
### Summary 💡

Update `minio-ha` images to their latest versions

Closes: [#569](https://github.com/sighupio/product-management/issues/569)

### Description 📝

- Updated `minio` chart to `5.4.0`
- Updated `minio` image tag to `RELEASE.2025-02-28T09-55-16Z`
- Updated `minio/mc` image tag to `RELEASE.2025-02-21T16-00-46Z`
- Updated MAINTENANCE.md guidelines with more precise instructions
- Moved version pinning from `kustomization.yaml` to setting the related values when templating from Helm

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Verified there are no differences between outputs from `kustomize@3.10.0` and `kustomize@5.6.0`
- [x] Tested clean install on kind
- [x] Tested an upgrade with `furyctl` from KFD v1.31.0 to this version
