### PR TITLE
chore: explicitly enable discover_log_levels in Loki configuration files to allow use of Grafana Drilldown plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 .envrc
 .tool-versions
 *built*
+/.idea/
+/.venv/

--- a/katalog/loki-distributed/MAINTENANCE.values.yaml
+++ b/katalog/loki-distributed/MAINTENANCE.values.yaml
@@ -84,6 +84,7 @@ loki:
     enabled: true
   limits_config:
     allow_structured_metadata: true
+    discover_log_levels: true
     volume_enabled: true
 ######################################################################################################################
 #

--- a/katalog/loki-distributed/configs/config.yaml
+++ b/katalog/loki-distributed/configs/config.yaml
@@ -51,6 +51,7 @@ ingester:
     flush_on_shutdown: true
 limits_config:
   allow_structured_metadata: true
+  discover_log_levels: true
   max_cache_freshness_per_query: 10m
   query_timeout: 300s
   reject_old_samples: true


### PR DESCRIPTION
### Summary 💡

Explicitly enable discover_log_levels in Loki configuration files to allow use of Grafana Drilldown plugin.


### Description 📝

Explicitly enable discover_log_levels in Loki configuration files to allow use of Grafana Drilldown plugin.
The default is already true.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

CI: https://ci.sighup.io/sighupio/module-logging/2078

### Future work 🔧

Enable Grafana drilldown plugin in module-monitoring.
