### PR TITLE
feat: update logging operated to v6.5.1

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -7,10 +7,10 @@ This is a major release that adds HAProxy ingress controller logging support and
 ## Component Images 🚢
 
 | Component               | Supported Version                                                                                  | Previous Version |
-| ----------------------- | -------------------------------------------------------------------------------------------------- | ---------------- |
+| ----------------------- |----------------------------------------------------------------------------------------------------|------------------|
 | `opensearch`            | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.2.0)                    | `No Update`      |
 | `opensearch-dashboards` | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.2.0)         | `No Update`      |
-| `logging-operator`      | [`v6.0.3`](https://github.com/kube-logging/logging-operator/releases/tag/6.0.3)                    | `No Update`      |
+| `logging-operator`      | [`v6.5.1`](https://github.com/kube-logging/logging-operator/releases/tag/6.5.1)                    | `6.0.3`          |
 | `loki-distributed`      | [`v3.5.3`](https://github.com/grafana/loki/releases/tag/v3.5.3)                                    | `No Update`      |
 | `minio-ha`              | [`RELEASE.2025-09-07T16-13-09Z`](https://github.com/minio/minio/tree/RELEASE.2025-09-07T16-13-09Z) | `No Update`      |
 

--- a/katalog/logging-operated/MAINTENANCE.md
+++ b/katalog/logging-operated/MAINTENANCE.md
@@ -1,17 +1,17 @@
 # Logging Operated Maintenance Guide
 
-This folder contains tailor made files to deploy the Fluentd and Fluent-bit stack via Logging operator CRDs.
+This folder contains tailor-made files to deploy the Fluentd and Fluent-bit stack via Logging operator CRDs.
 
 Container Images for Fluentd and Fluent-bit compatibility with logging-operator can be found here: <https://kube-logging.dev/docs/image-versions/>
 
 Replace all images used in [`fluentd-fluentbit.yml`] with the ones you found in the above link.
 
-## Version 6.0.3 Compatible Images
+## Version 6.5.1 Compatible Images
 
-For logging-operator v6.0.3, use the following compatible versions:
-- **Fluentd**: `6.0.3-full` (registry.sighup.io/fury/banzaicloud/fluentd:6.0.3-full)
-- **Fluent-bit**: `4.0.3` (registry.sighup.io/fury/fluent/fluent-bit:4.0.3)
-- **Config-reloader**: `6.0.3` (registry.sighup.io/fury/banzaicloud/config-reloader:6.0.3)
+For logging-operator v6.5.1, use the following compatible versions:
+- **Fluentd**: `6.5.1-full` (registry.sighup.io/fury/banzaicloud/fluentd:6.5.1-full)
+- **Fluent-bit**: `5.0.5` (registry.sighup.io/fury/fluent/fluent-bit:5.0.5)
+- **Config-reloader**: `6.5.1` (registry.sighup.io/fury/banzaicloud/config-reloader:6.5.1)
 
 ## Grafana Dashboard
 

--- a/katalog/logging-operated/README.md
+++ b/katalog/logging-operated/README.md
@@ -15,9 +15,9 @@ It also deploys a MinIO instance for storing all the logs rejected from the conf
 
 ## Image repository and tag
 
-- Fluentd: `ghcr.io/kube-logging/logging-operator/fluentd:6.0.3-full`
-- Fluent Bit: `ghcr.io/fluent/fluent-bit:4.0.3`
-- Config Reloader: `ghcr.io/kube-logging/logging-operator/config-reloader:6.0.3`
+- Fluentd: `ghcr.io/kube-logging/logging-operator/fluentd:6.5.1-full`
+- Fluent Bit: `ghcr.io/fluent/fluent-bit:5.0.5`
+- Config Reloader: `ghcr.io/kube-logging/logging-operator/config-reloader:6.5.1`
 
 ## Configuration
 

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -14,10 +14,10 @@ spec:
     logLevel: debug
     image:
       repository: registry.sighup.io/fury/banzaicloud/fluentd
-      tag: 6.0.3-full
+      tag: 6.5.1-full
     configReloaderImage:
       repository: registry.sighup.io/fury/banzaicloud/config-reloader
-      tag: "6.0.3"
+      tag: 6.5.1
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -56,7 +56,7 @@ metadata:
 spec:
   image:
     repository: registry.sighup.io/fury/fluent/fluent-bit
-    tag: "4.0.3"
+    tag: 5.0.5
   enableUpstream: true
   inputTail:
     Ignore_Older: 86400s


### PR DESCRIPTION
### Summary 💡

Update logging operated to v6.5.1

### Description 📝

Following https://kube-logging.dev/docs/image-versions/#logging-operator-version-651 :
- Updated banzaicloud/fluentd to 6.5.1-full
- Updated banzaicloud/config-reloader to 6.5.1
- Updated fluent/fluent-bit to 5.0.5

### Breaking Changes 💔

Not affected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2099
- I tested that there are no conflicts between the old and new manifests by upgrading

### Future work 🔧

Update logging-operator component.
