### PR TITLE
feat: update logging-operator with helm chart v6.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following packages are included in the Logging module:
 | [opensearch-single](katalog/opensearch-single)         | `v3.2.0`                       | Single node opensearch deployment. Not intended for production use.                  |
 | [opensearch-triple](katalog/opensearch-triple)         | `v3.2.0`                       | Three node high-availability opensearch deployment                                   |
 | [opensearch-dashboards](katalog/opensearch-dashboards) | `v3.2.0`                       | Analytics and visualization platform for Opensearch                                  |
-| [logging-operator](katalog/logging-operator)           | `v6.0.3`                       | Banzai logging operator, manages fluentbit/fluentd and their configurations          |
+| [logging-operator](katalog/logging-operator)           | `v6.5.1`                       | Banzai logging operator, manages fluentbit/fluentd and their configurations          |
 | [logging-operated](katalog/logging-operated)           | `-`                            | fluentd and fluentbit deployment using logging operator                              |
 | [configs](katalog/configs)                             | `-`                            | Logging pipeline configs to gather various types of logs and send them to OpenSearch |
 | [loki-configs](katalog/loki-configs)                   | `-`                            | Logging pipeline configs to gather various types of logs and send them to Loki       |

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,4 +1,4 @@
-# Logging Core Module Release v6.0.0
+# Logging Core Module Release v5.4.0
 
 Welcome to the latest release of the `logging` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 

--- a/katalog/logging-operated/fluentd-fluentbit.yml
+++ b/katalog/logging-operated/fluentd-fluentbit.yml
@@ -38,6 +38,7 @@ spec:
     scaling:
       replicas: 2
     metrics:
+      enabled: true
       serviceMonitor: true
       prometheusRules: true
     resources:
@@ -72,6 +73,7 @@ spec:
     - operator: Exists
       effect: NoSchedule
   metrics:
+    enabled: true
     serviceMonitor: true
     prometheusRules: true
   resources:

--- a/katalog/logging-operator/MAINTENANCE.md
+++ b/katalog/logging-operator/MAINTENANCE.md
@@ -4,7 +4,7 @@ To maintain the Logging Operator package, you should follow these steps.
 
 1. Take note of the latest chart version from [`logging-operator` chart](https://github.com/kube-logging/logging-operator/releases).
 2. Take note also of the latest pushed version of the [`fury/banzaicloud/logging-operator`](https://registry.sighup.io/harbor/projects/37/repositories/banzaicloud%2Flogging-operator/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [fury-distribution-container-image-sync](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/logging/images.yml#L156) git repo
+    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
 
 3. Run the following commands:
 

--- a/katalog/logging-operator/MAINTENANCE.md
+++ b/katalog/logging-operator/MAINTENANCE.md
@@ -2,32 +2,16 @@
 
 To maintain the Logging Operator package, you should follow these steps.
 
-1. Take note of the latest chart version from [`logging-operator` chart](https://github.com/kube-logging/logging-operator/releases).
-2. Take note also of the latest pushed version of the [`fury/banzaicloud/logging-operator`](https://registry.sighup.io/harbor/projects/37/repositories/banzaicloud%2Flogging-operator/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
+1. Take note of the latest chart version from [`logging-operator` chart](https://github.com/kube-logging/logging-operator/releases). 
+   - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
+   - **NOTE:** the chart version here MUST be kept in sync with the data plane images used in [`../logging-operated/`](../logging-operated/MAINTENANCE.md).
 
-3. Run the following commands:
-
-  ```bash
-  VERSION=6.0.3 # update this to the latest chart version
-  IMAGE_TAG="6.0.3" # update this to the latest fury/banzaicloud/logging-operator image tag
-  helm pull oci://ghcr.io/kube-logging/helm-charts/logging-operator --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/logging-operator
-  helm template logging-operator /tmp/logging-operator/ --values MAINTENANCE.values.yaml --api-versions "monitoring.coreos.com/v1" --set "image.tag"="$IMAGE_TAG" -n logging > logging-operator-built.yaml
-  cp /tmp/logging-operator/crds/* ./crds
-  cd ./crds; for file in $(ls logging*); do kustomize edit add resource $file 2>/dev/null; done; cd .. # ensure we add new CRDs (if any) to the kustomization file
-  addlicense -c "SIGHUP s.r.l" -v -l bsd . # install with "go install github.com/google/addlicense@v1.1.1"
-  ```
+2. Run the upgrade script, specifying the desired chart version:
+   ```bash
+   LOGGING_CHART_VERSION=6.5.1 ./upgrade.sh
+   ```
 
 What was customized (what differs from the helm template command):
 
 - Removed openshift-related permissions from ClusterRole
 - Removed some labels in rbac resources
-
-Review the differences between `logging-operator-built.yaml` and `deploy.yaml`, make the customization described above and replace `deploy.yaml` with the contents of `minio-built.yaml`.
-
-Cleanup:
-
-```bash
-rm logging-operator-built.yaml
-rm -rf /tmp/logging-operator
-```

--- a/katalog/logging-operator/MAINTENANCE.values.yaml
+++ b/katalog/logging-operator/MAINTENANCE.values.yaml
@@ -9,7 +9,6 @@
 replicaCount: 1
 image:
   repository: registry.sighup.io/fury/banzaicloud/logging-operator
-  tag: ""
   pullPolicy: IfNotPresent
 
 env: []

--- a/katalog/logging-operator/README.md
+++ b/katalog/logging-operator/README.md
@@ -15,7 +15,7 @@ and a Fluentd StatefulSet that receive logs from Fluent-bit and send them to var
 
 ## Image repository and tag
 
-- Logging operator: `ghcr.io/kube-logging/logging-operator:6.0.3`
+- Logging operator: `ghcr.io/kube-logging/logging-operator:6.5.1`
 - Logging operator repo: [Logging operator on GitHub][logging-operator-github]
 
 ## Configuration

--- a/katalog/logging-operator/crds/kustomization.yaml
+++ b/katalog/logging-operator/crds/kustomization.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
+++ b/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_eventtailers.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: eventtailers.logging-extensions.banzaicloud.io
 spec:
   group: logging-extensions.banzaicloud.io
@@ -2314,6 +2314,29 @@ spec:
                                           type: object
                                         type: array
                                         x-kubernetes-list-type: atomic
+                                    type: object
+                                  podCertificate:
+                                    properties:
+                                      certificateChainPath:
+                                        type: string
+                                      credentialBundlePath:
+                                        type: string
+                                      keyPath:
+                                        type: string
+                                      keyType:
+                                        type: string
+                                      maxExpirationSeconds:
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
                                     type: object
                                   secret:
                                     properties:

--- a/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/katalog/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: hosttailers.logging-extensions.banzaicloud.io
 spec:
   group: logging-extensions.banzaicloud.io
@@ -2479,6 +2479,29 @@ spec:
                                           type: object
                                         type: array
                                         x-kubernetes-list-type: atomic
+                                    type: object
+                                  podCertificate:
+                                    properties:
+                                      certificateChainPath:
+                                        type: string
+                                      credentialBundlePath:
+                                        type: string
+                                      keyPath:
+                                        type: string
+                                      keyType:
+                                        type: string
+                                      maxExpirationSeconds:
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
                                     type: object
                                   secret:
                                     properties:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_axosyslogs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_axosyslogs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: axosyslogs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusterflows.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusterflows.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: clusteroutputs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -3473,6 +3473,8 @@ spec:
                     type: boolean
                   scram_mechanism:
                     type: string
+                  share_producer:
+                    type: boolean
                   slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
@@ -6085,6 +6087,238 @@ spec:
                 type: object
               protected:
                 type: boolean
+              rabbitmq:
+                properties:
+                  app_id:
+                    type: string
+                  auth_mechanism:
+                    type: string
+                  automatically_recover:
+                    type: boolean
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  connection_timeout:
+                    type: integer
+                  content_encoding:
+                    type: string
+                  content_type:
+                    type: string
+                  continuation_timeout:
+                    type: integer
+                  exchange:
+                    type: string
+                  exchange_durable:
+                    type: boolean
+                  exchange_no_declare:
+                    type: boolean
+                  exchange_type:
+                    type: string
+                  expiration:
+                    type: integer
+                  format:
+                    properties:
+                      add_newline:
+                        type: boolean
+                      message_key:
+                        type: string
+                      type:
+                        enum:
+                        - out_file
+                        - json
+                        - ltsv
+                        - csv
+                        - msgpack
+                        - hash
+                        - single_value
+                        type: string
+                    type: object
+                  frame_max:
+                    type: integer
+                  heartbeat:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  id_key:
+                    type: string
+                  message_type:
+                    type: string
+                  network_recovery_interval:
+                    type: integer
+                  pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  persistent:
+                    type: boolean
+                  port:
+                    type: integer
+                  priority:
+                    type: integer
+                  recovery_attempts:
+                    type: integer
+                  routing_key:
+                    type: string
+                  timestamp:
+                    type: boolean
+                  tls:
+                    type: boolean
+                  tls_ca_certificates:
+                    items:
+                      type: string
+                    type: array
+                  tls_cert:
+                    type: string
+                  tls_key:
+                    type: string
+                  user:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  verify_peer:
+                    type: boolean
+                  vhost:
+                    type: string
+                required:
+                - exchange
+                - exchange_type
+                type: object
               redis:
                 properties:
                   allow_duplicate_key:
@@ -11144,6 +11378,8 @@ spec:
                     type: boolean
                   scram_mechanism:
                     type: string
+                  share_producer:
+                    type: boolean
                   slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
@@ -13756,6 +13992,238 @@ spec:
                 type: object
               protected:
                 type: boolean
+              rabbitmq:
+                properties:
+                  app_id:
+                    type: string
+                  auth_mechanism:
+                    type: string
+                  automatically_recover:
+                    type: boolean
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  connection_timeout:
+                    type: integer
+                  content_encoding:
+                    type: string
+                  content_type:
+                    type: string
+                  continuation_timeout:
+                    type: integer
+                  exchange:
+                    type: string
+                  exchange_durable:
+                    type: boolean
+                  exchange_no_declare:
+                    type: boolean
+                  exchange_type:
+                    type: string
+                  expiration:
+                    type: integer
+                  format:
+                    properties:
+                      add_newline:
+                        type: boolean
+                      message_key:
+                        type: string
+                      type:
+                        enum:
+                        - out_file
+                        - json
+                        - ltsv
+                        - csv
+                        - msgpack
+                        - hash
+                        - single_value
+                        type: string
+                    type: object
+                  frame_max:
+                    type: integer
+                  heartbeat:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  id_key:
+                    type: string
+                  message_type:
+                    type: string
+                  network_recovery_interval:
+                    type: integer
+                  pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  persistent:
+                    type: boolean
+                  port:
+                    type: integer
+                  priority:
+                    type: integer
+                  recovery_attempts:
+                    type: integer
+                  routing_key:
+                    type: string
+                  timestamp:
+                    type: boolean
+                  tls:
+                    type: boolean
+                  tls_ca_certificates:
+                    items:
+                      type: string
+                    type: array
+                  tls_cert:
+                    type: string
+                  tls_key:
+                    type: string
+                  user:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  verify_peer:
+                    type: boolean
+                  vhost:
+                    type: string
+                required:
+                - exchange
+                - exchange_type
+                type: object
               redis:
                 properties:
                   allow_duplicate_key:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_flows.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: flows.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: fluentbitagents.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -793,6 +793,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   path:
@@ -804,6 +806,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -883,7 +889,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -930,7 +935,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -1206,6 +1210,23 @@ spec:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            optional:
+                              default: false
+                              type: boolean
+                            path:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
                         resourceFieldRef:
                           properties:
                             containerName:
@@ -1334,6 +1355,8 @@ spec:
                   Kube_URL:
                     type: string
                   Kube_meta_preload_cache_dir:
+                    type: string
+                  Kubelet_Host:
                     type: string
                   Kubelet_Port:
                     type: string
@@ -1511,6 +1534,8 @@ spec:
                 properties:
                   Require_ack_response:
                     type: boolean
+                  Retain_Metadata_In_Forward_Mode:
+                    type: boolean
                   Retry_Limit:
                     type: string
                   Send_options:
@@ -1575,6 +1600,8 @@ spec:
                   Docker_Mode_Parser:
                     type: string
                   Exclude_Path:
+                    type: string
+                  File_Cache_Advise:
                     type: string
                   Ignore_Older:
                     type: string
@@ -1712,6 +1739,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   path:
@@ -1723,6 +1752,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -1802,7 +1835,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -1849,7 +1881,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -2720,6 +2751,10 @@ spec:
                 type: string
               targetPort:
                 format: int32
+                type: integer
+              terminationGracePeriodSeconds:
+                format: int64
+                minimum: 0
                 type: integer
               tls:
                 properties:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: fluentdconfigs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -783,6 +783,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   path:
@@ -794,6 +796,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -873,7 +879,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -920,7 +925,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -1228,6 +1232,23 @@ spec:
                               type: string
                           required:
                           - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            optional:
+                              default: false
+                              type: boolean
+                            path:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
@@ -1867,6 +1888,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   path:
@@ -1878,6 +1901,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -1957,7 +1984,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -2004,7 +2030,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -2608,6 +2633,113 @@ spec:
                   serviceAccount:
                     type: string
                 type: object
+              service:
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        type: boolean
+                      clusterIP:
+                        type: string
+                      clusterIPs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalName:
+                        type: string
+                      externalTrafficPolicy:
+                        type: string
+                      healthCheckNodePort:
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        type: string
+                      ipFamilies:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        type: string
+                      loadBalancerClass:
+                        type: string
+                      loadBalancerIP:
+                        type: string
+                      loadBalancerSourceRanges:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ports:
+                        items:
+                          properties:
+                            appProtocol:
+                              type: string
+                            name:
+                              type: string
+                            nodePort:
+                              format: int32
+                              type: integer
+                            port:
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        type: string
+                      sessionAffinityConfig:
+                        properties:
+                          clientIP:
+                            properties:
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      trafficDistribution:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                type: object
               serviceAccount:
                 properties:
                   automountServiceAccountToken:
@@ -2696,6 +2828,23 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -3126,6 +3275,29 @@ spec:
                       type: object
                     restartPolicy:
                       type: string
+                    restartPolicyRules:
+                      items:
+                        properties:
+                          action:
+                            type: string
+                          exitCodes:
+                            properties:
+                              operator:
+                                type: string
+                              values:
+                                items:
+                                  format: int32
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: set
+                            required:
+                            - operator
+                            type: object
+                        required:
+                        - action
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                     securityContext:
                       properties:
                         allowPrivilegeEscalation:
@@ -3339,6 +3511,10 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              terminationGracePeriodSeconds:
+                format: int64
+                minimum: 0
+                type: integer
               tls:
                 properties:
                   enabled:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_loggingroutes.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_loggingroutes.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: loggingroutes.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: loggings.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -886,6 +886,11 @@ spec:
                 type: boolean
               flowConfigOverride:
                 type: string
+              fluentBitAgentNamespace:
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, please recreate the resource
+                  rule: self == oldSelf
               fluentbit:
                 properties:
                   HostNetwork:
@@ -1649,6 +1654,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       path:
@@ -1660,6 +1667,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -1739,7 +1750,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -1786,7 +1796,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -2062,6 +2071,23 @@ spec:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
                             resourceFieldRef:
                               properties:
                                 containerName:
@@ -2190,6 +2216,8 @@ spec:
                       Kube_URL:
                         type: string
                       Kube_meta_preload_cache_dir:
+                        type: string
+                      Kubelet_Host:
                         type: string
                       Kubelet_Port:
                         type: string
@@ -2367,6 +2395,8 @@ spec:
                     properties:
                       Require_ack_response:
                         type: boolean
+                      Retain_Metadata_In_Forward_Mode:
+                        type: boolean
                       Retry_Limit:
                         type: string
                       Send_options:
@@ -2431,6 +2461,8 @@ spec:
                       Docker_Mode_Parser:
                         type: string
                       Exclude_Path:
+                        type: string
+                      File_Cache_Advise:
                         type: string
                       Ignore_Older:
                         type: string
@@ -2568,6 +2600,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       path:
@@ -2579,6 +2613,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -2658,7 +2696,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -2705,7 +2742,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -3577,6 +3613,10 @@ spec:
                   targetPort:
                     format: int32
                     type: integer
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    minimum: 0
+                    type: integer
                   tls:
                     properties:
                       enabled:
@@ -4367,6 +4407,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       path:
@@ -4378,6 +4420,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -4457,7 +4503,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -4504,7 +4549,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -4812,6 +4856,23 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -5451,6 +5512,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       path:
@@ -5462,6 +5525,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -5541,7 +5608,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -5588,7 +5654,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -6192,6 +6257,113 @@ spec:
                       serviceAccount:
                         type: string
                     type: object
+                  service:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            type: boolean
+                          clusterIP:
+                            type: string
+                          clusterIPs:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            type: string
+                          ipFamilies:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            type: string
+                          loadBalancerClass:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          trafficDistribution:
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                    type: object
                   serviceAccount:
                     properties:
                       automountServiceAccountToken:
@@ -6280,6 +6452,23 @@ spec:
                                         type: string
                                     required:
                                     - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -6710,6 +6899,29 @@ spec:
                           type: object
                         restartPolicy:
                           type: string
+                        restartPolicyRules:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              exitCodes:
+                                properties:
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -6923,6 +7135,10 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    minimum: 0
+                    type: integer
                   tls:
                     properties:
                       enabled:
@@ -7817,6 +8033,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       mount_name:
@@ -7830,6 +8048,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -7909,7 +8131,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -7956,7 +8177,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -8797,6 +9017,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -9225,6 +9462,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -9506,6 +9766,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -9934,6 +10211,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -10221,6 +10521,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -10649,6 +10966,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -11652,6 +11992,29 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         properties:
                                           items:
@@ -11847,6 +12210,8 @@ spec:
                       tag:
                         type: string
                     type: object
+                  enabledIPv6:
+                    type: boolean
                   globalOptions:
                     properties:
                       log_level:
@@ -11873,6 +12238,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      enabled:
+                        type: boolean
                       interval:
                         type: string
                       path:
@@ -11884,6 +12251,10 @@ spec:
                         type: boolean
                       prometheusRules:
                         type: boolean
+                      prometheusRulesLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       prometheusRulesOverride:
                         items:
                           properties:
@@ -11963,7 +12334,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -12010,7 +12380,6 @@ spec:
                                   type: string
                                 sourceLabels:
                                   items:
-                                    pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                     type: string
                                   type: array
                                 targetLabel:
@@ -12992,6 +13361,23 @@ spec:
                                                     - fieldPath
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
                                                   resourceFieldRef:
                                                     properties:
                                                       containerName:
@@ -13420,6 +13806,29 @@ spec:
                                           type: object
                                         restartPolicy:
                                           type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         securityContext:
                                           properties:
                                             allowPrivilegeEscalation:
@@ -13701,6 +14110,23 @@ spec:
                                                     - fieldPath
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
                                                   resourceFieldRef:
                                                     properties:
                                                       containerName:
@@ -14129,6 +14555,29 @@ spec:
                                           type: object
                                         restartPolicy:
                                           type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         securityContext:
                                           properties:
                                             allowPrivilegeEscalation:
@@ -14416,6 +14865,23 @@ spec:
                                                     - fieldPath
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
                                                   resourceFieldRef:
                                                     properties:
                                                       containerName:
@@ -14844,6 +15310,29 @@ spec:
                                           type: object
                                         restartPolicy:
                                           type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
                                         securityContext:
                                           properties:
                                             allowPrivilegeEscalation:
@@ -15847,6 +16336,29 @@ spec:
                                                         type: array
                                                         x-kubernetes-list-type: atomic
                                                     type: object
+                                                  podCertificate:
+                                                    properties:
+                                                      certificateChainPath:
+                                                        type: string
+                                                      credentialBundlePath:
+                                                        type: string
+                                                      keyPath:
+                                                        type: string
+                                                      keyType:
+                                                        type: string
+                                                      maxExpirationSeconds:
+                                                        format: int32
+                                                        type: integer
+                                                      signerName:
+                                                        type: string
+                                                      userAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    required:
+                                                    - keyType
+                                                    - signerName
+                                                    type: object
                                                   secret:
                                                     properties:
                                                       items:
@@ -16167,6 +16679,10 @@ spec:
                       tag:
                         type: string
                     type: object
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    minimum: 0
+                    type: integer
                   tls:
                     properties:
                       enabled:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: outputs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -3473,6 +3473,8 @@ spec:
                     type: boolean
                   scram_mechanism:
                     type: string
+                  share_producer:
+                    type: boolean
                   slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
@@ -10202,6 +10204,8 @@ spec:
                     type: boolean
                   scram_mechanism:
                     type: string
+                  share_producer:
+                    type: boolean
                   slow_flush_log_threshold:
                     type: string
                   ssl_ca_cert:
@@ -12811,6 +12815,238 @@ spec:
                 - access_key_secret
                 - bucket
                 - endpoint
+                type: object
+              rabbitmq:
+                properties:
+                  app_id:
+                    type: string
+                  auth_mechanism:
+                    type: string
+                  automatically_recover:
+                    type: boolean
+                  buffer:
+                    properties:
+                      chunk_full_threshold:
+                        type: string
+                      chunk_limit_records:
+                        type: integer
+                      chunk_limit_size:
+                        type: string
+                      compress:
+                        type: string
+                      delayed_commit_timeout:
+                        type: string
+                      disable_chunk_backup:
+                        type: boolean
+                      disabled:
+                        type: boolean
+                      flush_at_shutdown:
+                        type: boolean
+                      flush_interval:
+                        type: string
+                      flush_mode:
+                        type: string
+                      flush_thread_burst_interval:
+                        type: string
+                      flush_thread_count:
+                        type: integer
+                      flush_thread_interval:
+                        type: string
+                      overflow_action:
+                        type: string
+                      path:
+                        type: string
+                      queue_limit_length:
+                        type: integer
+                      queued_chunks_limit_size:
+                        type: integer
+                      retry_exponential_backoff_base:
+                        type: string
+                      retry_forever:
+                        type: boolean
+                      retry_max_interval:
+                        type: string
+                      retry_max_times:
+                        type: integer
+                      retry_randomize:
+                        type: boolean
+                      retry_secondary_threshold:
+                        type: string
+                      retry_timeout:
+                        type: string
+                      retry_type:
+                        type: string
+                      retry_wait:
+                        type: string
+                      tags:
+                        type: string
+                      timekey:
+                        type: string
+                      timekey_use_utc:
+                        type: boolean
+                      timekey_wait:
+                        type: string
+                      timekey_zone:
+                        type: string
+                      total_limit_size:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  connection_timeout:
+                    type: integer
+                  content_encoding:
+                    type: string
+                  content_type:
+                    type: string
+                  continuation_timeout:
+                    type: integer
+                  exchange:
+                    type: string
+                  exchange_durable:
+                    type: boolean
+                  exchange_no_declare:
+                    type: boolean
+                  exchange_type:
+                    type: string
+                  expiration:
+                    type: integer
+                  format:
+                    properties:
+                      add_newline:
+                        type: boolean
+                      message_key:
+                        type: string
+                      type:
+                        enum:
+                        - out_file
+                        - json
+                        - ltsv
+                        - csv
+                        - msgpack
+                        - hash
+                        - single_value
+                        type: string
+                    type: object
+                  frame_max:
+                    type: integer
+                  heartbeat:
+                    type: string
+                  host:
+                    type: string
+                  hosts:
+                    items:
+                      type: string
+                    type: array
+                  id_key:
+                    type: string
+                  message_type:
+                    type: string
+                  network_recovery_interval:
+                    type: integer
+                  pass:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  persistent:
+                    type: boolean
+                  port:
+                    type: integer
+                  priority:
+                    type: integer
+                  recovery_attempts:
+                    type: integer
+                  routing_key:
+                    type: string
+                  timestamp:
+                    type: boolean
+                  tls:
+                    type: boolean
+                  tls_ca_certificates:
+                    items:
+                      type: string
+                    type: array
+                  tls_cert:
+                    type: string
+                  tls_key:
+                    type: string
+                  user:
+                    properties:
+                      mountFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      value:
+                        type: string
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
+                  verify_peer:
+                    type: boolean
+                  vhost:
+                    type: string
+                required:
+                - exchange
+                - exchange_type
                 type: object
               redis:
                 properties:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngclusterflows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngclusterflows.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syslogngclusterflows.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syslogngclusteroutputs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngconfigs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngconfigs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syslogngconfigs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io
@@ -34,6 +34,8 @@ spec:
             properties:
               bufferVolumeMetrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   mount_name:
@@ -47,6 +49,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -126,7 +132,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -173,7 +178,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -1014,6 +1018,23 @@ spec:
                                     - fieldPath
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -1442,6 +1463,29 @@ spec:
                           type: object
                         restartPolicy:
                           type: string
+                        restartPolicyRules:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              exitCodes:
+                                properties:
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -1723,6 +1767,23 @@ spec:
                                     - fieldPath
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -2151,6 +2212,29 @@ spec:
                           type: object
                         restartPolicy:
                           type: string
+                        restartPolicyRules:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              exitCodes:
+                                properties:
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -2438,6 +2522,23 @@ spec:
                                     - fieldPath
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -2866,6 +2967,29 @@ spec:
                           type: object
                         restartPolicy:
                           type: string
+                        restartPolicyRules:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              exitCodes:
+                                properties:
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -3869,6 +3993,29 @@ spec:
                                         type: array
                                         x-kubernetes-list-type: atomic
                                     type: object
+                                  podCertificate:
+                                    properties:
+                                      certificateChainPath:
+                                        type: string
+                                      credentialBundlePath:
+                                        type: string
+                                      keyPath:
+                                        type: string
+                                      keyType:
+                                        type: string
+                                      maxExpirationSeconds:
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
                                   secret:
                                     properties:
                                       items:
@@ -4064,6 +4211,8 @@ spec:
                   tag:
                     type: string
                 type: object
+              enabledIPv6:
+                type: boolean
               globalOptions:
                 properties:
                   log_level:
@@ -4090,6 +4239,8 @@ spec:
                 type: integer
               metrics:
                 properties:
+                  enabled:
+                    type: boolean
                   interval:
                     type: string
                   path:
@@ -4101,6 +4252,10 @@ spec:
                     type: boolean
                   prometheusRules:
                     type: boolean
+                  prometheusRulesLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   prometheusRulesOverride:
                     items:
                       properties:
@@ -4180,7 +4335,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -4227,7 +4381,6 @@ spec:
                               type: string
                             sourceLabels:
                               items:
-                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
@@ -5209,6 +5362,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -5637,6 +5807,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -5918,6 +6111,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -6346,6 +6556,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -6633,6 +6866,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -7061,6 +7311,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -8064,6 +8337,29 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                properties:
+                                                  certificateChainPath:
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    type: string
+                                                  keyPath:
+                                                    type: string
+                                                  keyType:
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 properties:
                                                   items:
@@ -8384,6 +8680,10 @@ spec:
                   tag:
                     type: string
                 type: object
+              terminationGracePeriodSeconds:
+                format: int64
+                minimum: 0
+                type: integer
               tls:
                 properties:
                   enabled:

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngflows.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngflows.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syslogngflows.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/katalog/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syslogngoutputs.logging.banzaicloud.io
 spec:
   group: logging.banzaicloud.io

--- a/katalog/logging-operator/deploy.yaml
+++ b/katalog/logging-operator/deploy.yaml
@@ -11,267 +11,275 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-6.0.3
+    helm.sh/chart: logging-operator-6.5.1
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "6.0.3"
+    app.kubernetes.io/version: "6.5.1"
     app.kubernetes.io/managed-by: Helm
+  annotations:
 ---
 # Source: logging-operator/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: logging-operator
+  annotations:
+  labels:
+    app.kubernetes.io/name: logging-operator
+    helm.sh/chart: logging-operator-6.5.1
+    app.kubernetes.io/instance: logging-operator
+    app.kubernetes.io/version: "6.5.1"
+    app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - persistentvolumeclaims
-  - pods
-  - secrets
-  - serviceaccounts
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - namespaces
-  - nodes
-  - nodes/proxy
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - '*'
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  - networking.k8s.io
-  resources:
-  - ingresses
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - extensions
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - use
-  - watch
-- apiGroups:
-  - logging-extensions.banzaicloud.io
-  resources:
-  - eventtailers
-  - hosttailers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - logging-extensions.banzaicloud.io
-  resources:
-  - eventtailers/status
-  - hosttailers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - logging.banzaicloud.io
-  resources:
-  - axosyslogs
-  - clusterflows
-  - clusteroutputs
-  - flows
-  - fluentbitagents
-  - fluentdconfigs
-  - loggingroutes
-  - loggings
-  - outputs
-  - syslogngclusterflows
-  - syslogngclusteroutputs
-  - syslogngconfigs
-  - syslogngflows
-  - syslogngoutputs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - logging.banzaicloud.io
-  resources:
-  - axosyslogs/status
-  - clusterflows/status
-  - clusteroutputs/status
-  - flows/status
-  - fluentbitagents/status
-  - fluentdconfigs/status
-  - loggingroutes/status
-  - loggings/status
-  - outputs/status
-  - syslogngclusterflows/status
-  - syslogngclusteroutputs/status
-  - syslogngconfigs/status
-  - syslogngflows/status
-  - syslogngoutputs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - logging.banzaicloud.io
-  resources:
-  - loggings/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheusrules
-  - servicemonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - telemetry.kube-logging.dev
-  resources:
-  - bridges
-  - collectors
-  - outputs
-  - subscriptions
-  - tenants
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - namespaces
+      - nodes
+      - nodes/proxy
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - '*'
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+      - policy
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - use
+      - watch
+  - apiGroups:
+      - logging-extensions.banzaicloud.io
+    resources:
+      - eventtailers
+      - hosttailers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - logging-extensions.banzaicloud.io
+    resources:
+      - eventtailers/status
+      - hosttailers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - logging.banzaicloud.io
+    resources:
+      - axosyslogs
+      - clusterflows
+      - clusteroutputs
+      - flows
+      - fluentbitagents
+      - fluentdconfigs
+      - loggingroutes
+      - loggings
+      - outputs
+      - syslogngclusterflows
+      - syslogngclusteroutputs
+      - syslogngconfigs
+      - syslogngflows
+      - syslogngoutputs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - logging.banzaicloud.io
+    resources:
+      - axosyslogs/status
+      - clusterflows/status
+      - clusteroutputs/status
+      - flows/status
+      - fluentbitagents/status
+      - fluentdconfigs/status
+      - loggingroutes/status
+      - loggings/status
+      - outputs/status
+      - syslogngclusterflows/status
+      - syslogngclusteroutputs/status
+      - syslogngconfigs/status
+      - syslogngflows/status
+      - syslogngoutputs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - logging.banzaicloud.io
+    resources:
+      - loggings/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - telemetry.kube-logging.dev
+    resources:
+      - bridges
+      - collectors
+      - outputs
+      - subscriptions
+      - tenants
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 # Source: logging-operator/templates/userrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -279,48 +287,49 @@ kind: ClusterRole
 metadata:
   name: logging-operator-edit
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-- apiGroups:
-  - logging.banzaicloud.io
-  resources:
-  - flows
-  - outputs
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - logging.banzaicloud.io
-  resources:
-  - syslogngflows
-  - syslogngoutputs
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - logging.banzaicloud.io
+    resources:
+      - flows
+      - outputs
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - logging.banzaicloud.io
+    resources:
+      - syslogngflows
+      - syslogngoutputs
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 # Source: logging-operator/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: logging-operator
+  annotations:
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-6.0.3
+    helm.sh/chart: logging-operator-6.5.1
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "6.0.3"
+    app.kubernetes.io/version: "6.5.1"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -339,9 +348,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-6.0.3
+    helm.sh/chart: logging-operator-6.5.1
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "6.0.3"
+    app.kubernetes.io/version: "6.5.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -363,9 +372,9 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-6.0.3
+    helm.sh/chart: logging-operator-6.5.1
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "6.0.3"
+    app.kubernetes.io/version: "6.5.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -381,7 +390,7 @@ spec:
     spec:
       containers:
         - name: logging-operator
-          image: "registry.sighup.io/fury/banzaicloud/logging-operator:6.0.3"
+          image: "registry.sighup.io/fury/banzaicloud/logging-operator:6.5.1"
           args:
             - -enable-leader-election=true
           imagePullPolicy: IfNotPresent
@@ -405,21 +414,21 @@ metadata:
   namespace: logging
   labels:
     app.kubernetes.io/name: logging-operator
-    helm.sh/chart: logging-operator-6.0.3
+    helm.sh/chart: logging-operator-6.5.1
     app.kubernetes.io/instance: logging-operator
-    app.kubernetes.io/version: "6.0.3"
+    app.kubernetes.io/version: "6.5.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: logging-operator
-      helm.sh/chart: logging-operator-6.0.3
+      helm.sh/chart: logging-operator-6.5.1
       app.kubernetes.io/instance: logging-operator
-      app.kubernetes.io/version: "6.0.3"
+      app.kubernetes.io/version: "6.5.1"
       app.kubernetes.io/managed-by: Helm
   endpoints:
-  - port: http
-    path: /metrics
+    - port: http
+      path: /metrics
   namespaceSelector:
     matchNames:
-    - logging
+      - logging

--- a/katalog/logging-operator/kustomization.yaml
+++ b/katalog/logging-operator/kustomization.yaml
@@ -16,4 +16,3 @@ resources:
 images:
   - name: ghcr.io/kube-logging/logging-operator
     newName: registry.sighup.io/fury/banzaicloud/logging-operator
-    newTag: "6.0.3"

--- a/katalog/logging-operator/upgrade.sh
+++ b/katalog/logging-operator/upgrade.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+if [ -z "${LOGGING_CHART_VERSION:-}" ]; then
+  echo "Usage: LOGGING_CHART_VERSION=6.7.0 ./upgrade.sh"
+  exit 1
+fi
+echo "Using chart version ${LOGGING_CHART_VERSION}"
+
+rm -rf /tmp/logging-operator
+helm template logging-operator oci://ghcr.io/kube-logging/helm-charts/logging-operator \
+  --version "${LOGGING_CHART_VERSION}" \
+  --values MAINTENANCE.values.yaml \
+  --api-versions "monitoring.coreos.com/v1" \
+  -n logging > deploy.yaml
+
+yq -i 'select(.kind == "ClusterRole" and .metadata.name == "logging-operator") |= del(.rules[] | select(.apiGroups[0] == "security.openshift.io"))' deploy.yaml
+echo "Removed OpenShift SCC permissions from CusterRole logging-operator"
+
+yq -i 'select(.kind == "ClusterRole" and .metadata.name == "logging-operator-edit") |= (.metadata.labels |= with_entries(select(.key | test("^rbac"))))' deploy.yaml
+echo "Filtered labels from ClusterRole logging-operator-edit"
+
+helm pull oci://ghcr.io/kube-logging/helm-charts/logging-operator --version "${LOGGING_CHART_VERSION}" --untar --untardir /tmp
+cp /tmp/logging-operator/crds/* ./crds
+(cd ./crds && for f in logging*; do kustomize edit add resource "$f" 2>/dev/null; done)
+echo "Copied CRDs to ./crds"
+
+rm -rf /tmp/logging-operator
+mise run add-license

--- a/katalog/minio-ha/MAINTENANCE.md
+++ b/katalog/minio-ha/MAINTENANCE.md
@@ -4,7 +4,7 @@ To maintain the MinIO package, you should follow these steps.
 
 1. Take note of the latest chart version from [Main Minio repository releases](https://github.com/minio/minio/releases).
 2. Take note also of the latest pushed version of both [`fury/minio`](https://registry.sighup.io/harbor/projects/37/repositories/minio/artifacts-tab`) and [`fury/minio/mc`](https://registry.sighup.io/harbor/projects/37/repositories/minio%2Fmc/artifacts-tab) images in our Harbor registry
-    - If necessary, add a newer version on our [fury-distribution-container-image-sync](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/dr/images.yml#L102) git repo
+    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/dr/images.yml) git repo
 
 3. Run the following commands:
 

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -4,7 +4,7 @@ To maintain the Opensearch Dashboards package, you should follow these steps.
 
 1. Take note of the latest chart version from [Opensearch Helm Charts][opensearch-helm-charts].
 2. Take note also of the latest pushed version of the [`fury/opensearchproject/opensearch-dashboards`](https://registry.sighup.io/harbor/projects/37/repositories/opensearchproject%2Fopensearch-dashboards/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [fury-distribution-container-image-sync](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/logging/images.yml#L36) git repo
+    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
 
 3. Run the following commands:
 

--- a/katalog/opensearch-single/MAINTENANCE.md
+++ b/katalog/opensearch-single/MAINTENANCE.md
@@ -4,7 +4,7 @@ To maintain the OpenSearch package, you should follow these steps.
 
 1. Take note of the latest chart version from [Opensearch Helm Charts][opensearch-helm-charts].
 2. Take note also of the latest pushed version of the [`fury/opensearchproject/opensearch`](https://registry.sighup.io/harbor/projects/37/repositories/opensearchproject%2Fopensearch/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [fury-distribution-container-image-sync](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/logging/images.yml#L36) git repo
+    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
 
 3. Run the following commands:
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,13 +6,13 @@
 kind = "0.32.0"
 kubectl = "1.35.6"
 kustomize = "5.6.0"
-helm = "3.15.0"    
-yq = "4.43.1"      
-go = "1.23"        
-bats = "1.11.0"    
-dyff = "1.9.0"    
+helm = "3.15.0"
+yq = "4.53.3"
+go = "1.23"
+bats = "1.11.0"
+dyff = "1.9.0"
 drone = "1.9.0"
-"ubi:google/addlicense" = "v1.1.1"     
+"ubi:google/addlicense" = "v1.1.1"
 
 # Development task definitions
 [tasks.add-license]


### PR DESCRIPTION
### Summary 💡

Update logging-operator with helm chart v6.5.1

### Description 📝

- Update logging-operator with helm chart v6.5.1
- Fixed container-image-sync references

### Breaking Changes 💔

We are mostly unaffected except for the `metrics.enabled` flag handled.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2103
- I tested that there are no conflicts between the old and new manifests by upgrading

### Future work 🔧

Update loki-distributed component.