### PR TITLE
feat: update opensearch-dashboards with chart version 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ High level diagram of the stack:
 The following packages are included in the Logging module:
 
 | Package                                                | Version                        | Description                                                                          |
-| ------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------ |
+|--------------------------------------------------------|--------------------------------|--------------------------------------------------------------------------------------|
 | [opensearch-single](katalog/opensearch-single)         | `v3.2.0`                       | Single node opensearch deployment. Not intended for production use.                  |
 | [opensearch-triple](katalog/opensearch-triple)         | `v3.2.0`                       | Three node high-availability opensearch deployment                                   |
-| [opensearch-dashboards](katalog/opensearch-dashboards) | `v3.2.0`                       | Analytics and visualization platform for Opensearch                                  |
+| [opensearch-dashboards](katalog/opensearch-dashboards) | `v3.7.0`                       | Analytics and visualization platform for Opensearch                                  |
 | [logging-operator](katalog/logging-operator)           | `v6.5.1`                       | Banzai logging operator, manages fluentbit/fluentd and their configurations          |
 | [logging-operated](katalog/logging-operated)           | `-`                            | fluentd and fluentbit deployment using logging operator                              |
 | [configs](katalog/configs)                             | `-`                            | Logging pipeline configs to gather various types of logs and send them to OpenSearch |
@@ -56,7 +56,7 @@ Click on each package to see its full documentation.
 ## Compatibility
 
 | Kubernetes Version |   Compatibility    | Notes           |
-| ------------------ | :----------------: | --------------- |
+|--------------------|:------------------:|-----------------|
 | `1.29.x`           | :white_check_mark: | No known issues |
 | `1.30.x`           | :white_check_mark: | No known issues |
 | `1.31.x`           | :white_check_mark: | No known issues |
@@ -71,13 +71,13 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 > [!NOTE]
 > Instructions below are for deploying the module using a legacy version of furyctl, that required manual intervention and managing each module individually.
 >
-> Latest versions of furyctl automate the whole cluster lifecycle and it is recommended to use the latest version of furyctl instead.
+> Latest versions of furyctl automate the whole cluster lifecycle, and it is recommended to use the latest version of furyctl instead.
 
 
 ### Prerequisites
 
 | Tool                        | Version    | Description                                                                                                                                                    |
-| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].      |
 | [kustomize][kustomize-repo] | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -6,12 +6,12 @@ This is a major release that adds HAProxy ingress controller logging support and
 
 ## Component Images 🚢
 
-| Component               | Supported Version                                                                                  | Previous Version |
-| ----------------------- |----------------------------------------------------------------------------------------------------|------------------|
-| `opensearch`            | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.2.0)                    | `No Update`      |
-| `opensearch-dashboards` | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.2.0)         | `No Update`      |
-| `logging-operator`      | [`v6.5.1`](https://github.com/kube-logging/logging-operator/releases/tag/6.5.1)                    | `6.0.3`          |
-| `loki-distributed`      | [`v3.7.2`](https://github.com/grafana/loki/releases/tag/v3.7.2)                                    | `v3.5.3`         |
+| Component               | Supported Version                                                                                             | Previous Version               |
+|-------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `opensearch`            | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.2.0)                               | `No Update`                    |
+| `opensearch-dashboards` | [`v3.7.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.7.0)                    | `v3.2.0`                       |
+| `logging-operator`      | [`v6.5.1`](https://github.com/kube-logging/logging-operator/releases/tag/6.5.1)                               | `6.0.3`                        |
+| `loki-distributed`      | [`v3.7.2`](https://github.com/grafana/loki/releases/tag/v3.7.2)                                               | `v3.5.3`                       |
 | `minio-ha`              | [`RELEASE.2026-05-20T23-44-52Z`](https://github.com/chainguard-forks/minio/tree/RELEASE.2026-05-20T23-44-52Z) | `RELEASE.2025-09-07T16-13-09Z` |
 
 ## New Features 🎉

--- a/katalog/configs/README.md
+++ b/katalog/configs/README.md
@@ -15,16 +15,16 @@ This package is a collection of logging operator Flow/ClusterFlow and Output/Clu
 
 Configurations available:
 
-- [configs](configs): all the configurations.
-- [configs/kubernetes](configs/kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
-- [configs/infra](configs/infra): only the infrastructural namespaces logs
-- [configs/ingress-nginx](configs/ingress-nginx): only the nginx-ingress-controller logging configuration.
-- [configs/ingress-haproxy](configs/ingress-haproxy): only the haproxy-ingress-controller logging configuration.
-- [configs/audit](configs/audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
-- [configs/events](configs/events): all the Kubernetes events related configurations (with master selector and tolerations).
-- [configs/systemd](configs/systemd): all the systemd related configurations.
-- [configs/systemd/kubelet](configs/systemd/common): kubelet, docker, ssh systemd service logs configuration.
-- [configs/systemd/etcd](configs/systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
+- [configs](.): all the configurations.
+- [configs/kubernetes](./kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
+- [configs/infra](./infra): only the infrastructural namespaces logs
+- [configs/ingress-nginx](./ingress-nginx): only the nginx-ingress-controller logging configuration.
+- [configs/ingress-haproxy](./ingress-haproxy): only the haproxy-ingress-controller logging configuration.
+- [configs/audit](./audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
+- [configs/events](./events): all the Kubernetes events related configurations (with master selector and tolerations).
+- [configs/systemd](./systemd): all the systemd-related configurations.
+- [configs/systemd/kubelet](./systemd/common): kubelet, docker, ssh systemd service logs configuration.
+- [configs/systemd/etcd](./systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
 
 ## Deployment
 

--- a/katalog/loki-distributed/MAINTENANCE.md
+++ b/katalog/loki-distributed/MAINTENANCE.md
@@ -10,7 +10,7 @@ The upgrade is handled automatically by `upgrade.sh`. First, find the latest cha
 ```bash
 helm repo add grafana-community https://grafana-community.github.io/helm-charts
 helm repo update
-helm search repo grafana-community/loki -o json | jq -r '.[0].version'
+helm search repo grafana-community/loki -o json
 ```
 
 Then run:

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -1,39 +1,22 @@
 # Opensearch Dashboards - maintenance
 
-To maintain the Opensearch Dashboards package, you should follow these steps.
+The upgrade is handled automatically by `upgrade.sh`. First, find the latest chart version:
 
-1. Take note of the latest chart version from [Opensearch Helm Charts][opensearch-helm-charts].
-2. Take note also of the latest pushed version of the [`fury/opensearchproject/opensearch-dashboards`](https://registry.sighup.io/harbor/projects/37/repositories/opensearchproject%2Fopensearch-dashboards/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
+```bash
+helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo update
+helm search repo opensearch-dashboard -o json
+```
 
-3. Run the following commands:
+Then run:
 
-  ```bash
-  VERSION=3.2.1 # update this to the latest chart version
-  IMAGE_TAG="3.2.0" # update this to the latest fury/opensearchproject/opensearch-dashboards image tag
-  helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-  helm repo update
-  helm pull opensearch/opensearch-dashboards --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/opensearch-dashboards
-  helm template opensearch-dashboards /tmp/opensearch-dashboards/ --values MAINTENANCE.values.yaml --set "image.tag"="$IMAGE_TAG" -n logging > opensearch-dashboards-built.yaml
-  IMAGE_TAG="$IMAGE_TAG" yq -i '(.images[] | select(.name == "*opensearchproject/opensearch-dashboards")).newTag |= env(IMAGE_TAG)' kustomization.yaml
-  ```
-
-  > [!TIP]
-  > Chart v3.2.1 uses OpenSearch Dashboards v3.2.0
+```bash
+OPENSEARCH_CHART_VERSION=3.7.0 ./upgrade.sh
+```
 
 What was customized:
 
-- removed Helm labels
 - opensearch-dashboards created with secretGenerator
 - security plugin is disabled with a custom command for the container, we expect security on the ingress level or configured manually (in consequence `OPENSEARCH_HOSTS` is switched to http)
-
-Review the differences between `opensearch-dashboards-built.yaml` and `deploy.yaml`, make the customization described above and replace `deploy.yaml` with the contents of `opensearch-dashboards-built.yaml`.
-
-Cleanup:
-
-```bash
-rm opensearch-dashboards-built.yaml
-rm -rf /tmp/opensearch-dashboards
-```
 
 [opensearch-helm-charts]: https://github.com/opensearch-project/helm-charts/releases

--- a/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
+++ b/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
@@ -10,8 +10,6 @@ replicaCount: 1
 
 image:
   repository: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards"
-  # override image tag, which is .Chart.AppVersion by default
-  tag: "3.2.0"
   pullPolicy: "IfNotPresent"
 
 startupProbe:
@@ -41,7 +39,7 @@ readinessProbe:
   successThreshold: 1
   initialDelaySeconds: 10
 
-imagePullSecrets: []
+imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
@@ -49,7 +47,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
-  annotations: {}
+  annotations: { }
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
@@ -60,21 +58,21 @@ rbac:
 # A list of secrets and their paths to mount inside the pod
 # This is useful for mounting certificates for security and for mounting
 # the X-Pack license
-secretMounts: []
+secretMounts: [ ]
 #  - name: certs
 #    secretName: dashboard-certs
 #    path: /usr/share/dashboards/certs
 
-podAnnotations: {}
+podAnnotations: { }
 
 # Deployment annotations
-dashboardAnnotations: {}
+dashboardAnnotations: { }
 
-extraEnvs: []
+extraEnvs: [ ]
 #  - name: "NODE_OPTIONS"
 #    value: "--max-old-space-size=1800"
 
-envFrom: []
+envFrom: [ ]
 
 extraVolumes:
   - name: opensearch-dashboards
@@ -90,7 +88,7 @@ extraInitContainers: ""
 
 extraContainers: ""
 
-podSecurityContext: {}
+podSecurityContext: { }
 
 securityContext:
   capabilities:
@@ -100,7 +98,7 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-config: {}
+config: { }
   # Default OpenSearch Dashboards configuration from docker image of Dashboards
 
   #  opensearch_dashboards.yml: |
@@ -122,9 +120,9 @@ config: {}
 
   # determines how dashboards will verify certificates (needs to be none for default opensearch certificates to work)
   # opensearch:
-  #   ssl:
-  #     certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
-  #     if utilizing custom CA certs for connection to opensearch, provide the CA here
+#   ssl:
+#     certificateAuthorities: /usr/share/opensearch-dashboards/certs/dashboards-root-ca.pem
+#     if utilizing custom CA certs for connection to opensearch, provide the CA here
 
 opensearchDashboardsYml:
   defaultMode:
@@ -137,9 +135,9 @@ opensearchAccount:
   keyPassphrase:
     enabled: false
 
-labels: {}
+labels: { }
 
-hostAliases: []
+hostAliases: [ ]
 # - ip: "127.0.0.1"
 #   hostnames:
 #   - "foo.local"
@@ -160,9 +158,9 @@ service:
   metricsPort: 9601
   loadBalancerIP: ""
   nodePort: ""
-  labels: {}
-  annotations: {}
-  loadBalancerSourceRanges: []
+  labels: { }
+  annotations: { }
+  loadBalancerSourceRanges: [ ]
   # 0.0.0.0/0
   httpPortName: http
   metricsPortName: metrics
@@ -172,10 +170,10 @@ ingress:
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   # ingressClassName: nginx
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  labels: {}
+  annotations: { }
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  labels: { }
   hosts:
     - host: chart-example.local
       paths:
@@ -183,7 +181,7 @@ ingress:
           backend:
             serviceName: ""
             servicePort: ""
-  tls: []
+  tls: [ ]
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
@@ -209,18 +207,18 @@ autoscaling:
 updateStrategy:
   type: "Recreate"
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }
 
 # This is the pod topology spread constraints
 # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
-topologySpreadConstraints: []
+topologySpreadConstraints: [ ]
 
 # -- Array of extra K8s manifests to deploy
-extraObjects: []
+extraObjects: [ ]
   # - apiVersion: secrets-store.csi.x-k8s.io/v1
   #   kind: SecretProviderClass
   #   metadata:
@@ -256,12 +254,12 @@ extraObjects: []
   #    spec:
   #      minAvailable: 1
   #      selector:
-  #        matchLabels:
+#        matchLabels:
 #          {{- include "opensearch-dashboards.selectorLabels" . | nindent 6 }}
 
 # pod lifecycle policies as outlined here:
 # https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
-lifecycle: {}
+lifecycle: { }
   # preStop:
   #   exec:
   #     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
@@ -270,17 +268,17 @@ lifecycle: {}
   #     command:
   #       - bash
   #       - -c
-  #       - |
-  #         #!/bin/bash
-  #         curl -I "http://admin:admin@127.0.0.1:5601/status -H "kbn-xsrf: true" -H 'kbn-xsrf: true' -H "Content-Type: application/json"
+#       - |
+#         #!/bin/bash
+#         curl -I "http://admin:admin@127.0.0.1:5601/status -H "kbn-xsrf: true" -H 'kbn-xsrf: true' -H "Content-Type: application/json"
 
 ## Enable to add 3rd Party / Custom plugins not offered in the default OpenSearchDashboards image.
 plugins:
-  enabled: false
-  installList: []
+  enabled: true
+  installList: [ ]
   # - example-fake-plugin-downloadable-url
-  removeList: []
-  # - examplePluginName
+  removeList:
+    - securityDashboards
 
 # ServiceMonitor Configuration for Prometheus
 # Enabling this option will create a ServiceMonitor resource that allows Prometheus to scrape metrics from the OpenSearch service.
@@ -299,4 +297,4 @@ serviceMonitor:
   # additional labels to be added to the ServiceMonitor
   # labels:
   #  k8s.example.com/prometheus: kube-prometheus
-  labels: {}
+  labels: { }

--- a/katalog/opensearch-dashboards/README.md
+++ b/katalog/opensearch-dashboards/README.md
@@ -14,7 +14,7 @@ stored in OpenSearch indices.
 
 ## Image repository and tag
 
-* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:3.2.0`
+* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:3.7.0`
 * OpenSearch Dashboards repo: [OpenSearch Dashboards on Github][opensearch-dashboards-github]
 * OpenSearch Dashboards documentation: [OpenSearch Dashboards at opensearch.org][opensearch-dashboards-doc]
 

--- a/katalog/opensearch-dashboards/deploy.yaml
+++ b/katalog/opensearch-dashboards/deploy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -9,16 +9,22 @@ kind: ServiceAccount
 metadata:
   name: opensearch-dashboards-dashboards
   labels:
+    helm.sh/chart: opensearch-dashboards-3.7.0
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
 ---
 # Source: opensearch-dashboards/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
+    helm.sh/chart: opensearch-dashboards-3.7.0
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
   name: opensearch-dashboards-dashboards-rolebinding
 roleRef:
   kind: Role
@@ -35,8 +41,11 @@ kind: Service
 metadata:
   name: opensearch-dashboards
   labels:
+    helm.sh/chart: opensearch-dashboards-3.7.0
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
   ports:
@@ -57,8 +66,11 @@ kind: Deployment
 metadata:
   name: opensearch-dashboards
   labels:
+    helm.sh/chart: opensearch-dashboards-3.7.0
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   strategy:
@@ -72,6 +84,7 @@ spec:
       labels:
         app.kubernetes.io/name: opensearch-dashboards
         app.kubernetes.io/instance: opensearch-dashboards
+      annotations:
     spec:
       securityContext:
         {}
@@ -91,14 +104,8 @@ spec:
             - ALL
           runAsNonRoot: true
           runAsUser: 1000
-        image: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards:3.2.0"
+        image: "registry.sighup.io/fury/opensearchproject/opensearch-dashboards:3.7.0"
         imagePullPolicy: "IfNotPresent"
-        command:
-          - /bin/bash
-          - -c
-          - |
-            /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
-            ./opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards
         readinessProbe:
           failureThreshold: 10
           initialDelaySeconds: 10
@@ -132,6 +139,16 @@ spec:
         - containerPort: 5601
           name: http
           protocol: TCP
+        command:
+          - sh
+          - -c
+          - |
+            #!/usr/bin/bash
+            set -e
+            if ./bin/opensearch-dashboards-plugin list | grep -q securityDashboards; then
+              ./bin/opensearch-dashboards-plugin remove securityDashboards
+            fi
+            bash opensearch-dashboards-docker-entrypoint.sh opensearch-dashboards
         resources:
           limits:
             cpu: 100m
@@ -154,8 +171,11 @@ metadata:
   name: opensearch-dashboards-service-monitor
   namespace: logging
   labels:
+    helm.sh/chart: opensearch-dashboards-3.7.0
     app.kubernetes.io/name: opensearch-dashboards
     app.kubernetes.io/instance: opensearch-dashboards
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
 spec:
   selector:
     matchLabels:

--- a/katalog/opensearch-dashboards/kustomization.yaml
+++ b/katalog/opensearch-dashboards/kustomization.yaml
@@ -2,21 +2,20 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: logging
 resources:
-  - deploy.yaml
-  - index-patterns-cronjob.yml
+- deploy.yaml
+- index-patterns-cronjob.yml
 images:
-  - name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "3.2.0"
+- name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
+  newTag: 3.7.0
 secretGenerator:
-  - name: opensearch-dashboards
-    files:
-      - configs/opensearch_dashboards.yml
+- files:
+  - configs/opensearch_dashboards.yml
+  name: opensearch-dashboards
 configMapGenerator:
-  - name: opensearch-index-patterns
-    files:
-      - configs/index-patterns.ndjson
+- files:
+  - configs/index-patterns.ndjson
+  name: opensearch-index-patterns

--- a/katalog/opensearch-dashboards/upgrade.sh
+++ b/katalog/opensearch-dashboards/upgrade.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+if [ -z "${OPENSEARCH_CHART_VERSION:-}" ]; then
+  echo "Usage: OPENSEARCH_CHART_VERSION=3.7.0 ./upgrade.sh"
+  exit 1
+fi
+echo "Using chart version ${OPENSEARCH_CHART_VERSION}"
+
+helm template opensearch-dashboards opensearch/opensearch-dashboards \
+  --values MAINTENANCE.values.yaml \
+  -n logging > deploy.yaml
+echo "Generated template in deploy.yaml"
+
+OPENSEARCH_APP_VERSION=$(helm show chart opensearch/opensearch-dashboards --version ${OPENSEARCH_CHART_VERSION} | yq '.appVersion')
+echo "Found app version ${OPENSEARCH_APP_VERSION}"
+
+kustomize edit set image registry.sighup.io/fury/opensearchproject/opensearch-dashboards:${OPENSEARCH_APP_VERSION}
+echo "Patched kustomization.yaml with OpenSearch Dashboards version ${OPENSEARCH_APP_VERSION}"
+
+mise run add-license

--- a/katalog/opensearch-triple/README.md
+++ b/katalog/opensearch-triple/README.md
@@ -6,7 +6,7 @@ OpenSearch is an open-source distributed search and analytics engine used for
 log analytics. This package deploys a three-node OpenSearch cluster on
 Kubernetes.
 
-`opensearch-triple` is a high availability setup of OpenSearch, that sets
+`opensearch-triple` is a high-availability setup of OpenSearch, that sets
 up a 3-node cluster of `OpenSearch` for a robust and reliable setup.
 
 ## Requirements
@@ -37,7 +37,7 @@ OpenSearch Triple is deployed with the following configuration:
 - Requires `30Gi` storage
 - Each OpenSearch node is running in a different Kubernetes node
 - Prometheus exporter to expose OpenSearch metrics
-- Metrics are scraped by Prometheus every `30s`
+- Prometheus scrapes metrics every `30s`
 
 ## Deployment
 


### PR DESCRIPTION
### Summary 💡

Update opensearch-dashboards with chart version 3.7.0

### Description 📝

Update opensearch-dashboards with chart version 3.7.0


### Breaking Changes 💔

Not detected. Changes should not affect us.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2150
- I tested that there are no conflicts between the old and new manifests by upgrading

### Future work 🔧

Upgrade opensearch-single component.
