### PR TITLE
feat: update opensearch-single with chart version 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ If you are new to SD please refer to the [official documentation][kfd-docs] on h
 The central piece of the stack is the open source search engine [opensearch][opensearch-page], combined
 with its analytics and visualization platform [opensearch-dashboards][opensearch-dashboards-page].
 The logs are collected using a node-level data collection and enrichment agent [fluentbit][fluentbit-page],
-pushing it to the OpenSearch via [fluentd][fluentd-page]. The fluentbit and fluentd stack is managed by Banzai Logging Operator.
+pushing it to the OpenSearch via [fluentd][fluentd-page]. The fluentbit and fluentd stack are managed by Banzai Logging Operator.
 We are also providing an alternative to OpenSearch: [loki][loki-page].
 
 All the components are deployed in the `logging` namespace in the cluster.
 
-High level diagram of the stack:
+High-level diagram of the stack:
 
 ![logging module](docs/images/diagram.png "Logging Module")
 
@@ -41,8 +41,8 @@ The following packages are included in the Logging module:
 
 | Package                                                | Version                        | Description                                                                          |
 |--------------------------------------------------------|--------------------------------|--------------------------------------------------------------------------------------|
-| [opensearch-single](katalog/opensearch-single)         | `v3.2.0`                       | Single node opensearch deployment. Not intended for production use.                  |
-| [opensearch-triple](katalog/opensearch-triple)         | `v3.2.0`                       | Three node high-availability opensearch deployment                                   |
+| [opensearch-single](katalog/opensearch-single)         | `v3.7.0`                       | Single node opensearch deployment. Not intended for production use.                  |
+| [opensearch-triple](katalog/opensearch-triple)         | `v3.7.0`                       | Three node high-availability opensearch deployment                                   |
 | [opensearch-dashboards](katalog/opensearch-dashboards) | `v3.7.0`                       | Analytics and visualization platform for Opensearch                                  |
 | [logging-operator](katalog/logging-operator)           | `v6.5.1`                       | Banzai logging operator, manages fluentbit/fluentd and their configurations          |
 | [logging-operated](katalog/logging-operated)           | `-`                            | fluentd and fluentbit deployment using logging operator                              |
@@ -109,21 +109,21 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 4. Define a `kustomization.yaml` that includes the `./vendor/katalog/logging` directory as resource.
 
-```yaml
-resources:
-- ./vendor/katalog/logging/opensearch-single
-- ./vendor/katalog/logging/opensearch-dashboards
-- ./vendor/katalog/logging/logging-operator
-- ./vendor/katalog/logging/logging-operated
-- ./vendor/katalog/logging/minio-ha
-- ./vendor/katalog/logging/configs
-``
+   ```yaml
+   resources:
+   - ./vendor/katalog/logging/opensearch-single
+   - ./vendor/katalog/logging/opensearch-dashboards
+   - ./vendor/katalog/logging/logging-operator
+   - ./vendor/katalog/logging/logging-operated
+   - ./vendor/katalog/logging/minio-ha
+   - ./vendor/katalog/logging/configs
+   ```
 
 5. To deploy the packages to your cluster, execute:
 
-```bash
-kustomize build . | kubectl apply --server-side -f -
-```
+   ```bash
+   kustomize build . | kubectl apply --server-side -f -
+   ```
 
 > Note: When installing the packages, you need to ensure that the Prometheus operator is also installed.
 > Otherwise, the API server will reject all ServiceMonitor resources.
@@ -156,29 +156,29 @@ kustomize build . | kubectl apply --server-side -f -
 
 4. Define a `kustomization.yaml` that includes the `./vendor/katalog/logging` directory as resource.
 
-```yaml
-resources:
-- ./vendor/katalog/logging/loki-distributed
-- ./vendor/katalog/logging/logging-operator
-- ./vendor/katalog/logging/logging-operated
-- ./vendor/katalog/logging/minio-ha
-- ./vendor/katalog/logging/loki-configs
-``
+   ```yaml
+   resources:
+   - ./vendor/katalog/logging/loki-distributed
+   - ./vendor/katalog/logging/logging-operator
+   - ./vendor/katalog/logging/logging-operated
+   - ./vendor/katalog/logging/minio-ha
+   - ./vendor/katalog/logging/loki-configs
+   ```
 
 5. To deploy the packages to your cluster, execute:
 
-```bash
-kustomize build . | kubectl apply --server-side -f -
-```
+   ```bash
+   kustomize build . | kubectl apply --server-side -f -
+   ```
 
 > Note: When installing the packages, you need to ensure that the Prometheus operator is also installed.
 > Otherwise, the API server will reject all ServiceMonitor resources.
 
-### Common Customisations
+### Common Customizations
 
 #### Setup a high-availability three-node OpenSearch
 
-Logging module offers an out of the box, highly-available setup for `opensearch` instead of a single node version. To set this up, in the `Furyfile` and `kustomization`, you can replace `opensearch-single` with `opensearch-triple`.
+Logging module offers an out-of-the-box, highly available setup for `opensearch` instead of a single node version. To set this up, in the `Furyfile` and `kustomization`, you can replace `opensearch-single` with `opensearch-triple`.
 
 #### Configure tolerations and node selectors
 
@@ -211,6 +211,6 @@ In case you experience any problems with the module, please [open a new issue](h
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source, and it's released under the following [LICENSE](LICENSE)
 
 <!-- </FOOTER> -->

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -8,7 +8,7 @@ This is a major release that adds HAProxy ingress controller logging support and
 
 | Component               | Supported Version                                                                                             | Previous Version               |
 |-------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------|
-| `opensearch`            | [`v3.2.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.2.0)                               | `No Update`                    |
+| `opensearch`            | [`v3.7.0`](https://github.com/opensearch-project/OpenSearch/releases/tag/3.7.0)                               | `v3.2.0`                      |
 | `opensearch-dashboards` | [`v3.7.0`](https://github.com/opensearch-project/OpenSearch-Dashboards/releases/tag/3.7.0)                    | `v3.2.0`                       |
 | `logging-operator`      | [`v6.5.1`](https://github.com/kube-logging/logging-operator/releases/tag/6.5.1)                               | `6.0.3`                        |
 | `loki-distributed`      | [`v3.7.2`](https://github.com/grafana/loki/releases/tag/v3.7.2)                                               | `v3.5.3`                       |

--- a/katalog/loki-distributed/MAINTENANCE.md
+++ b/katalog/loki-distributed/MAINTENANCE.md
@@ -10,7 +10,7 @@ The upgrade is handled automatically by `upgrade.sh`. First, find the latest cha
 ```bash
 helm repo add grafana-community https://grafana-community.github.io/helm-charts
 helm repo update
-helm search repo grafana-community/loki -o json
+helm search repo grafana-community/loki
 ```
 
 Then run:

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -3,9 +3,9 @@
 The upgrade is handled automatically by `upgrade.sh`. First, find the latest chart version:
 
 ```bash
-helm repo add opensearch https://opensearch-project.github.io/helm-charts/
+helm repo add opensearch https://opensearch-project.github.io/helm-charts
 helm repo update
-helm search repo opensearch-dashboard -o json
+helm search repo opensearch-dashboard
 ```
 
 Then run:

--- a/katalog/opensearch-single/MAINTENANCE.md
+++ b/katalog/opensearch-single/MAINTENANCE.md
@@ -1,45 +1,35 @@
 # OpenSearch - maintenance
 
-To maintain the OpenSearch package, you should follow these steps.
 
-1. Take note of the latest chart version from [Opensearch Helm Charts][opensearch-helm-charts].
-2. Take note also of the latest pushed version of the [`fury/opensearchproject/opensearch`](https://registry.sighup.io/harbor/projects/37/repositories/opensearchproject%2Fopensearch/artifacts-tab`) image in our Harbor registry
-    - If necessary, add a newer version on our [container-image-sync](https://github.com/sighupio/container-image-sync/blob/main/modules/logging/images.yml) git repo
+The upgrade is handled automatically by `upgrade.sh`. First, find the latest chart version:
 
-3. Run the following commands:
+```bash
+helm repo add opensearch https://opensearch-project.github.io/helm-charts
+helm repo update
+helm search repo opensearch/opensearch
+```
 
-  ```bash
-  VERSION=3.2.0 # update this to the latest chart version
-  IMAGE_TAG="3.2.0" # update this to the latest fury/opensearchproject/opensearch image tag
-  helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-  helm repo update
-  helm pull opensearch/opensearch --version $VERSION --untar --untardir /tmp # this command will download the chart in /tmp/opensearch
-  helm template opensearch /tmp/opensearch/ --values MAINTENANCE.values.yaml --set "image.tag"="$IMAGE_TAG" -n logging > opensearch-built.yaml
-  IMAGE_TAG="$IMAGE_TAG" yq -i '(.images[] | select(.name == "*opensearchproject/opensearch-dashboards")).newTag |= env(IMAGE_TAG)' kustomization.yaml
-  ```
+Then run:
 
-  > [!TIP]
-  > Chart v3.2.0 uses OpenSearch v3.2.0
+```bash
+OPENSEARCH_CHART_VERSION=3.7.0 ./upgrade.sh
+```
 
 The provided values will deploy a custom `fsgroups` initContainer, because the one provided with vanilla values
 does not change the `fs.file-max` value with `sysctl`.
 We also added a custom sidecar container to export Prometheus metrics. We are using this strategy because the [prometheus-exporter](https://github.com/Aiven-Open/prometheus-exporter-plugin-for-opensearch) plugin is not compatible with the latest versions of OpenSearch yet.
 
-Manual changes from the output of `helm template`:
-
-- removed helm release labels
-
 Then, Kustomize will automate the following changes:
 
-- added custom prometheus AlertRules
-- security plugin is disabled via ConfigMap, we expect security on the ingress level or configured manually
-- change the `alpine` and `elasticsearch-exporter` images to use our Harbor registry
+- custom prometheus AlertRules
+- security plugin disabled via ConfigMap
+- image tag pinning for `alpine`, `elasticsearch-exporter`, and `opensearch-dashboards`
 
-Cleanup:
+## Prometheus metrics
 
-```bash
-rm opensearch-built.yaml
-rm -rf /tmp/opensearch
-```
+The upstream chart exposes a `metrics` port (`9600`) for OpenSearch's performance analyzer.
+We disable the performance analyzer and use an `elasticsearch-exporter` sidecar instead.
+
+`upgrade.sh` adds a `prom-metrics` port (`9108`) to both services so the ServiceMonitor (`sm.yml`) scrapes the exporter sidecar.
 
 [opensearch-helm-charts]: https://github.com/opensearch-project/helm-charts/releases

--- a/katalog/opensearch-single/MAINTENANCE.values.yaml
+++ b/katalog/opensearch-single/MAINTENANCE.values.yaml
@@ -16,6 +16,8 @@ roles:
   - data
   - remote_cluster_client
 replicas: 1
+global:
+  dockerRegistry: registry.sighup.io/fury/
 opensearchHome: /usr/share/opensearch
 config: null
 extraEnvs:
@@ -25,9 +27,6 @@ extraEnvs:
     value: "true"
 
 image:
-  repository: "registry.sighup.io/fury/opensearchproject/opensearch"
-  # override image tag, which is .Chart.AppVersion by default
-  tag: "3.2.0"
   pullPolicy: "IfNotPresent"
 
 opensearchJavaOpts: "-Xms2G -Xmx2G"
@@ -61,7 +60,7 @@ extraVolumeMounts:
 
 extraContainers:
   - name: exporter
-    image: "quay.io/prometheuscommunity/elasticsearch-exporter"
+    image: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
     args:
       - '--es.uri=http://localhost:9200'
       - '--collector.clustersettings'
@@ -70,7 +69,7 @@ extraContainers:
       - '--web.listen-address=:9108'
     ports:
       - containerPort: 9108
-        name: metrics
+        name: prom-metrics
     resources:
       limits:
         cpu: 200m
@@ -81,7 +80,7 @@ extraContainers:
 
 extraInitContainers:
   - name: fsgroup-volume
-    image: alpine
+    image: registry.sighup.io/fury/alpine
     command: ['sh', '-c']
     args:
       - |

--- a/katalog/opensearch-single/README.md
+++ b/katalog/opensearch-single/README.md
@@ -19,8 +19,8 @@ Kubernetes.
 
 ## Image repository and tag
 
-- OpenSearch image: `opensearchproject/opensearch:3.2.0`
-- OpenSearch repo: [OpenSearch on Github][opensearch-gh]
+- OpenSearch image: `opensearchproject/opensearch:3.7.0`
+- OpenSearch repo: [OpenSearch on GitHub][opensearch-gh]
 - OpenSearch documentation: [OpenSearch Homepage][opensearch-doc]
 
 ## Configuration
@@ -32,7 +32,7 @@ Fury distribution OpenSearch Single is deployed with the following configuration
 - Resource limits are `2000m` for CPU and `4G` for memory
 - Requires `30Gi` storage
 - Prometheus exporter to expose OpenSearch metrics
-- Metrics are scraped by Prometheus every `30s`
+- Prometheus scrapes metrics every `30s`
 
 ## Deployment
 
@@ -48,7 +48,7 @@ kustomize build | kubectl apply -f -
 Since we are configuring a `ServiceMonitor` in this package, the following Prometheus [alerts][opensearch-rules] are already defined:
 
 | Alert                          | Description                                                          | Severity | Interval |
-| ------------------------------ | -------------------------------------------------------------------- | -------- | :------: |
+|--------------------------------|----------------------------------------------------------------------|----------|:--------:|
 | OpenSearchClusterRed           | This alert fires when the health of the opensearch cluster is RED    | critical |   30m    |
 | OpenSearchYellow               | This alert fires when the health of the opensearch cluster is YELLOW | warning  |   30m    |
 | OpenSearchOfRelocationShards   | This alert fires when there are relocating shards for 30 minutes     | warning  |   30m    |

--- a/katalog/opensearch-single/deploy.yaml
+++ b/katalog/opensearch-single/deploy.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SIGHUP s.r.l All rights reserved.
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
@@ -9,8 +9,12 @@ kind: PodDisruptionBudget
 metadata:
   name: "opensearch-cluster-master-pdb"
   labels:
+    helm.sh/chart: opensearch-3.7.0
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-cluster-master
 spec:
   maxUnavailable: 1
   selector:
@@ -24,22 +28,31 @@ apiVersion: v1
 metadata:
   name: opensearch-cluster-master
   labels:
+    helm.sh/chart: opensearch-3.7.0
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
-  annotations:
-    {}
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-cluster-master
+  annotations: {}
 spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
   ports:
-  - name: http
-    protocol: TCP
-    port: 9200
-  - name: transport
-    protocol: TCP
-    port: 9300
+    - name: http
+      protocol: TCP
+      port: 9200
+    - name: transport
+      protocol: TCP
+      port: 9300
+    - name: metrics
+      protocol: TCP
+      port: 9600
+    - name: prom-metrics
+      protocol: TCP
+      port: 9108
 ---
 # Source: opensearch/templates/service.yaml
 kind: Service
@@ -47,8 +60,12 @@ apiVersion: v1
 metadata:
   name: opensearch-cluster-master-headless
   labels:
+    helm.sh/chart: opensearch-3.7.0
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-cluster-master
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -59,10 +76,15 @@ spec:
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
   ports:
-  - name: http
-    port: 9200
-  - name: transport
-    port: 9300
+    - name: http
+      port: 9200
+    - name: transport
+      port: 9300
+    - name: metrics
+      port: 9600
+    - name: prom-metrics
+      protocol: TCP
+      port: 9108
 ---
 # Source: opensearch/templates/statefulset.yaml
 apiVersion: apps/v1
@@ -70,8 +92,12 @@ kind: StatefulSet
 metadata:
   name: opensearch-cluster-master
   labels:
+    helm.sh/chart: opensearch-3.7.0
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/instance: opensearch
+    app.kubernetes.io/version: "3.7.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: opensearch-cluster-master
   annotations:
     majorVersion: "3"
 spec:
@@ -85,20 +111,25 @@ spec:
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
-      name: opensearch-cluster-master
-    spec:
-      accessModes:
-      - "ReadWriteOnce"
-      resources:
-        requests:
-          storage: "30Gi"
+    - metadata:
+        name: opensearch-cluster-master
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "30Gi"
   template:
     metadata:
       name: "opensearch-cluster-master"
       labels:
+        helm.sh/chart: opensearch-3.7.0
         app.kubernetes.io/name: opensearch
         app.kubernetes.io/instance: opensearch
+        app.kubernetes.io/version: "3.7.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: opensearch-cluster-master
+      annotations:
     spec:
       securityContext:
         fsGroup: 1000
@@ -107,147 +138,149 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                  - opensearch
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - opensearch
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/instance
+                      operator: In
+                      values:
+                        - opensearch
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - opensearch
       terminationGracePeriodSeconds: 120
       volumes:
-      # Currently some extra blocks accept strings
-      # to continue with backwards compatibility this is being kept
-      # whilst also allowing for yaml to be specified too.
-      - configMap:
-          name: opensearch-cluster-master-config
-        name: config
-      enableServiceLinks: true
-      initContainers:
-      # Currently some extra blocks accept strings
-      # to continue with backwards compatibility this is being kept
-      # whilst also allowing for yaml to be specified too.
-      - args:
-        - |
-          sysctl -a
-          MAX_MAP_COUNT=$(sysctl -a | grep max_map_count | cut -d " " -f3)
-          if [ "$MAX_MAP_COUNT" -gt "262143" ]; then
-            echo "Nothing to do, vm.max_map_count value is high enough"
-          else
-            echo "Changing vm.max_map_count value to 262144"
-            sysctl -w vm.max_map_count=262144
-            sysctl -p
-          fi
-          FILE_MAX=$(sysctl -a | grep file-max | cut -d " " -f3)
-          if [ "$FILE_MAX" -gt "524287" ]; then
-            echo "Nothing to do, fs.file-max value is high enough"
-          else
-            echo "Changing fs.file-max value to 524288"
-            sysctl -w fs.file-max=524288
-            sysctl -p
-          fi
-          chown -R 1000:1000 /usr/share/opensearch/data
-        command:
-        - sh
-        - -c
-        image: alpine
-        name: fsgroup-volume
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-        - mountPath: /usr/share/opensearch/data
-          name: opensearch-cluster-master
-      containers:
-      - name: "opensearch"
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 1000
-          runAsNonRoot: true
-          runAsUser: 1000
-        image: "registry.sighup.io/fury/opensearchproject/opensearch:3.2.0"
-        imagePullPolicy: "IfNotPresent"
-        readinessProbe:
-          failureThreshold: 3
-          periodSeconds: 5
-          tcpSocket:
-            port: 9200
-          timeoutSeconds: 3
-        startupProbe:
-          failureThreshold: 30
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          tcpSocket:
-            port: 9200
-          timeoutSeconds: 3
-        ports:
-        - name: http
-          containerPort: 9200
-        - name: transport
-          containerPort: 9300
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4G
-          requests:
-            cpu: 1500m
-            memory: 3G
-        env:
-        - name: node.name
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: cluster.initial_master_nodes
-          value: "opensearch-cluster-master-0,"
-        - name: discovery.seed_hosts
-          value: "opensearch-cluster-master-headless"
-        - name: cluster.name
-          value: "opensearch-cluster"
-        - name: network.host
-          value: "0.0.0.0"
-        - name: OPENSEARCH_JAVA_OPTS
-          value: "-Xms2G -Xmx2G"
-        - name: node.roles
-          value: "master,ingest,data,remote_cluster_client,"
-        - name: DISABLE_INSTALL_DEMO_CONFIG
-          value: "true"
-        - name: DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI
-          value: "true"
-        volumeMounts:
-        - name: "opensearch-cluster-master"
-          mountPath: /usr/share/opensearch/data
         # Currently some extra blocks accept strings
         # to continue with backwards compatibility this is being kept
         # whilst also allowing for yaml to be specified too.
-        - mountPath: /usr/share/opensearch/config/opensearch.yml
+        - configMap:
+            name: opensearch-cluster-master-config
           name: config
-          subPath: opensearch.yml
-      # Currently some extra blocks accept strings
-      # to continue with backwards compatibility this is being kept
-      # whilst also allowing for yaml to be specified too.
-      - args:
-        - --es.uri=http://localhost:9200
-        - --collector.clustersettings
-        - --es.indices
-        - --collector.snapshots
-        - --web.listen-address=:9108
-        image: quay.io/prometheuscommunity/elasticsearch-exporter
-        name: exporter
-        ports:
-        - containerPort: 9108
-          name: metrics
-        resources:
-          limits:
-            cpu: 200m
-            memory: 400Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
+      enableServiceLinks: true
+      initContainers:
+        # Currently some extra blocks accept strings
+        # to continue with backwards compatibility this is being kept
+        # whilst also allowing for yaml to be specified too.
+        - args:
+            - |
+              sysctl -a
+              MAX_MAP_COUNT=$(sysctl -a | grep max_map_count | cut -d " " -f3)
+              if [ "$MAX_MAP_COUNT" -gt "262143" ]; then
+                echo "Nothing to do, vm.max_map_count value is high enough"
+              else
+                echo "Changing vm.max_map_count value to 262144"
+                sysctl -w vm.max_map_count=262144
+                sysctl -p
+              fi
+              FILE_MAX=$(sysctl -a | grep file-max | cut -d " " -f3)
+              if [ "$FILE_MAX" -gt "524287" ]; then
+                echo "Nothing to do, fs.file-max value is high enough"
+              else
+                echo "Changing fs.file-max value to 524288"
+                sysctl -w fs.file-max=524288
+                sysctl -p
+              fi
+              chown -R 1000:1000 /usr/share/opensearch/data
+          command:
+            - sh
+            - -c
+          image: registry.sighup.io/fury/alpine
+          name: fsgroup-volume
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /usr/share/opensearch/data
+              name: opensearch-cluster-master
+      containers:
+        - name: "opensearch"
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          image: "registry.sighup.io/fury/opensearchproject/opensearch:3.7.0"
+          imagePullPolicy: "IfNotPresent"
+          readinessProbe:
+            failureThreshold: 3
+            periodSeconds: 5
+            tcpSocket:
+              port: 9200
+            timeoutSeconds: 3
+          startupProbe:
+            failureThreshold: 30
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            tcpSocket:
+              port: 9200
+            timeoutSeconds: 3
+          ports:
+            - name: http
+              containerPort: 9200
+            - name: transport
+              containerPort: 9300
+            - name: metrics
+              containerPort: 9600
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4G
+            requests:
+              cpu: 1500m
+              memory: 3G
+          env:
+            - name: node.name
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: cluster.initial_master_nodes
+              value: "opensearch-cluster-master-0,"
+            - name: discovery.seed_hosts
+              value: "opensearch-cluster-master-headless"
+            - name: cluster.name
+              value: "opensearch-cluster"
+            - name: network.host
+              value: "0.0.0.0"
+            - name: OPENSEARCH_JAVA_OPTS
+              value: "-Xms2G -Xmx2G"
+            - name: node.roles
+              value: "master,ingest,data,remote_cluster_client,"
+            - name: DISABLE_INSTALL_DEMO_CONFIG
+              value: "true"
+            - name: DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI
+              value: "true"
+          volumeMounts:
+            - name: "opensearch-cluster-master"
+              mountPath: /usr/share/opensearch/data
+            # Currently some extra blocks accept strings
+            # to continue with backwards compatibility this is being kept
+            # whilst also allowing for yaml to be specified too.
+            - mountPath: /usr/share/opensearch/config/opensearch.yml
+              name: config
+              subPath: opensearch.yml
+        # Currently some extra blocks accept strings
+        # to continue with backwards compatibility this is being kept
+        # whilst also allowing for yaml to be specified too.
+        - args:
+            - --es.uri=http://localhost:9200
+            - --collector.clustersettings
+            - --es.indices
+            - --collector.snapshots
+            - --web.listen-address=:9108
+          image: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
+          name: exporter
+          ports:
+            - containerPort: 9108
+              name: prom-metrics
+          resources:
+            limits:
+              cpu: 200m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi

--- a/katalog/opensearch-single/kustomization.yaml
+++ b/katalog/opensearch-single/kustomization.yaml
@@ -2,30 +2,25 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: logging
 images:
-  - name: registry.sighup.io/fury/opensearchproject/opensearch
-    newTag: "3.2.0"
-  - name: quay.io/prometheuscommunity/elasticsearch-exporter
-    newName: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
-    newTag: "v1.8.0"
-  - name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
-    newTag: "3.2.0"
-  - name: alpine
-    newName: registry.sighup.io/fury/alpine
-    newTag: "3.14"
+- name: registry.sighup.io/fury/alpine
+  newTag: "3.24"
+- name: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
+  newTag: 3.7.0
+- name: registry.sighup.io/fury/prometheuscommunity/elasticsearch-exporter
+  newTag: v1.10.0
 resources:
-  - deploy.yaml
-  - sm.yml
-  - rules.yml
-  - ism-policy-cronjob.yml
+- deploy.yaml
+- sm.yml
+- rules.yml
+- ism-policy-cronjob.yml
 configMapGenerator:
-  - name: opensearch-cluster-master-config
-    files:
-      - configs/opensearch.yml
-  - name: opensearch-ism-policies
-    files:
-      - configs/retention.json
+- files:
+  - configs/opensearch.yml
+  name: opensearch-cluster-master-config
+- files:
+  - configs/retention.json
+  name: opensearch-ism-policies

--- a/katalog/opensearch-single/sm.yml
+++ b/katalog/opensearch-single/sm.yml
@@ -12,7 +12,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: metrics
+    port: prom-metrics
   jobLabel: k8s-app
   namespaceSelector:
     matchNames:

--- a/katalog/opensearch-single/upgrade.sh
+++ b/katalog/opensearch-single/upgrade.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -euo pipefail
+
+if [ -z "${OPENSEARCH_CHART_VERSION:-}" ]; then
+  echo "Usage: OPENSEARCH_CHART_VERSION=3.7.0 ./upgrade.sh"
+  exit 1
+fi
+echo "Using chart version ${OPENSEARCH_CHART_VERSION}"
+
+helm template opensearch opensearch/opensearch \
+  --values MAINTENANCE.values.yaml \
+  -n logging > deploy.yaml
+echo "Generated template in deploy.yaml"
+
+yq -i 'select(.kind == "Service").spec.ports += {"name": "prom-metrics", "protocol": "TCP", "port": 9108}' deploy.yaml
+echo "Added prom-metrics port to services for exporter sidecar"
+
+OPENSEARCH_APP_VERSION=$(helm show chart opensearch/opensearch-dashboards --version ${OPENSEARCH_CHART_VERSION} | yq '.appVersion')
+echo "Found app version ${OPENSEARCH_APP_VERSION}"
+
+kustomize edit set image registry.sighup.io/fury/opensearchproject/opensearch-dashboards:${OPENSEARCH_APP_VERSION}
+echo "Patched kustomization.yaml with OpenSearch Dashboards version ${OPENSEARCH_APP_VERSION}"
+
+mise run add-license


### PR DESCRIPTION
### Summary 💡

Update opensearch-single with chart version 3.7.0


### Description 📝

Update opensearch-single with chart version 3.7.0


### Breaking Changes 💔

Handled.

- Rename port metrics:9108 to prom-metrics:9108 because the upstream chart now creates a same-name port (metrics) that points to 9600


### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2156
- I tested that there are no conflicts between the old and new manifests by upgrading

### Future work 🔧

Migrate scripts into mise tasks.
