### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,17 @@
 
 <!-- <SD-DOCS> -->
 
-**Logging Module** provides a logging stack for the [SIGHUP Distribution (SD)][kfd-repo].
+**Logging Module** provides a logging stack for [SIGHUP Distribution (SD)][kfd-repo].
 
 If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
-**Logging Module** uses a collection of open source tools to provide the most resilient and robust logging stack for the cluster.
+**Logging Module** uses a collection of open source tools to provide a resilient and robust logging stack for the cluster.
 
-The central piece of the stack is the open source search engine [opensearch][opensearch-page], combined
-with its analytics and visualization platform [opensearch-dashboards][opensearch-dashboards-page].
-The logs are collected using a node-level data collection and enrichment agent [fluentbit][fluentbit-page],
-pushing it to the OpenSearch via [fluentd][fluentd-page]. The fluentbit and fluentd stack are managed by Banzai Logging Operator.
-We are also providing an alternative to OpenSearch: [loki][loki-page].
+The central piece of the stack is the open source search engine [OpenSearch][opensearch-page], combined with its analytics and visualization platform [OpenSearch Dashboards][opensearch-dashboards-page]. Logs are collected by a node-level data collection and enrichment agent, [Fluent Bit][fluentbit-page], and pushed to OpenSearch through [Fluentd][fluentd-page]. The Fluent Bit and Fluentd stack is managed by the Logging Operator. [Loki][loki-page] is also available as an alternative log storage backend to OpenSearch.
 
 All the components are deployed in the `logging` namespace in the cluster.
-
-High-level diagram of the stack:
-
-![logging module](docs/images/diagram.png "Logging Module")
 
 ## Packages
 
@@ -69,121 +61,42 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
-> [!NOTE]
-> Instructions below are for deploying the module using a legacy version of furyctl, that required manual intervention and managing each module individually.
->
-> Latest versions of furyctl automate the whole cluster lifecycle, and it is recommended to use the latest version of furyctl instead.
+**Logging Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
+### Configuration
 
-### Prerequisites
+You configure the module under `spec.distribution.modules.logging` in your `furyctl.yaml`. The `type` field selects the logging stack to deploy: `opensearch`, `loki`, `customOutputs`, or `none` to disable the module. When using OpenSearch, `opensearch.type` selects a `single` or `triple` node deployment. The other fields are optional and fall back to sensible defaults.
 
-| Tool                        | Version    | Description                                                                                                                                                    |
-|-----------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].      |
-| [kustomize][kustomize-repo] | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
+```yaml
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      logging:
+        type: opensearch
+        opensearch:
+          type: single
+          storageSize: 150Gi
+```
 
-### Deployment with OpenSearch
+To use Loki as the log storage backend instead, set `type: loki` and choose the Loki storage backend with `loki.backend` (`minio` for an in-cluster MinIO deployment, or `externalEndpoint` for an external S3-compatible object storage):
 
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
+```yaml
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
+spec:
+  distribution:
+    modules:
+      logging:
+        type: loki
+        loki:
+          backend: minio
+```
 
-    ```yaml
-    bases:
-      - name: logging/opensearch-single
-        version: "v5.4.0"
-      - name: logging/opensearch-dashboards
-        version: "v5.4.0"
-      - name: logging/logging-operator
-        version: "v5.4.0"
-      - name: logging/logging-operated
-        version: "v5.4.0"
-      - name: minio/minio-ha
-        version: "v5.4.0"
-      - name: logging/configs
-        version: "v5.4.0"
-    ```
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-    > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/logging`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/logging` directory as resource.
-
-   ```yaml
-   resources:
-   - ./vendor/katalog/logging/opensearch-single
-   - ./vendor/katalog/logging/opensearch-dashboards
-   - ./vendor/katalog/logging/logging-operator
-   - ./vendor/katalog/logging/logging-operated
-   - ./vendor/katalog/logging/minio-ha
-   - ./vendor/katalog/logging/configs
-   ```
-
-5. To deploy the packages to your cluster, execute:
-
-   ```bash
-   kustomize build . | kubectl apply --server-side -f -
-   ```
-
-> Note: When installing the packages, you need to ensure that the Prometheus operator is also installed.
-> Otherwise, the API server will reject all ServiceMonitor resources.
-
-### Deployment with Loki
-
-1. List the packages you want to deploy and their version in a `Furyfile.yml`
-
-    ```yaml
-    bases:
-      - name: logging/loki-distributed
-        version: "v5.4.0"
-      - name: logging/logging-operator
-        version: "v5.4.0"
-      - name: logging/logging-operated
-        version: "v5.4.0"
-      - name: minio/minio-ha
-        version: "v5.4.0"
-      - name: logging/configs
-        version: "v5.4.0"
-      - name: logging/loki-configs
-        version: "v5.4.0"
-    ```
-
-    > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/logging`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/logging` directory as resource.
-
-   ```yaml
-   resources:
-   - ./vendor/katalog/logging/loki-distributed
-   - ./vendor/katalog/logging/logging-operator
-   - ./vendor/katalog/logging/logging-operated
-   - ./vendor/katalog/logging/minio-ha
-   - ./vendor/katalog/logging/loki-configs
-   ```
-
-5. To deploy the packages to your cluster, execute:
-
-   ```bash
-   kustomize build . | kubectl apply --server-side -f -
-   ```
-
-> Note: When installing the packages, you need to ensure that the Prometheus operator is also installed.
-> Otherwise, the API server will reject all ServiceMonitor resources.
-
-### Common Customizations
-
-#### Setup a high-availability three-node OpenSearch
-
-Logging module offers an out-of-the-box, highly available setup for `opensearch` instead of a single node version. To set this up, in the `Furyfile` and `kustomization`, you can replace `opensearch-single` with `opensearch-triple`.
-
-#### Configure tolerations and node selectors
-
-If you need to specify tolerations and/or node selectors, you can find some snippets in [examples/tolerations](examples/tolerations) and its subfolders.
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
@@ -194,9 +107,12 @@ If you need to specify tolerations and/or node selectors, you can find some snip
 [loki-page]: https://grafana.com/oss/loki/
 [kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 [kfd-docs]: https://docs.sighup.io/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/module-logging/blob/master/docs/COMPATIBILITY_MATRIX.md
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
+[getting-started]: https://docs.sighup.io/docs/getting-started/
+[compatibility-matrix]: https://github.com/sighupio/module-logging/blob/main/docs/COMPATIBILITY_MATRIX.md
 
 <!-- </SD-DOCS> -->
 
@@ -204,7 +120,7 @@ If you need to specify tolerations and/or node selectors, you can find some snip
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The central piece of the stack is the open source search engine [OpenSearch][ope
 
 All the components are deployed in the `logging` namespace in the cluster.
 
+High-level diagram of the stack:
+
+![logging module](docs/images/diagram.png "Logging Module")
+
 ## Packages
 
 The following packages are included in the Logging module:

--- a/katalog/configs/README.md
+++ b/katalog/configs/README.md
@@ -1,51 +1,16 @@
 # Logging operator configs for OpenSearch
 
-This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with **OpenSearch**.
+<!-- <SD-DOCS> -->
 
-> [!WARNING]
-> This package cannot be used together with `loki-configs` package, one excludes the other.
+## Overview
 
-## Requirements
-
-- Kustomize >= `5.6.0`
-- [logging-operated](../logging-operated)
-- [logging-operator](../logging-operator)
-
-## Configuration
-
-Configurations available:
-
-- [configs](.): all the configurations.
-- [configs/kubernetes](./kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
-- [configs/infra](./infra): only the infrastructural namespaces logs
-- [configs/ingress-nginx](./ingress-nginx): only the nginx-ingress-controller logging configuration.
-- [configs/ingress-haproxy](./ingress-haproxy): only the haproxy-ingress-controller logging configuration.
-- [configs/audit](./audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
-- [configs/events](./events): all the Kubernetes events related configurations (with master selector and tolerations).
-- [configs/systemd](./systemd): all the systemd-related configurations.
-- [configs/systemd/kubelet](./systemd/common): kubelet, docker, ssh systemd service logs configuration.
-- [configs/systemd/etcd](./systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
+This package is a collection of Logging Operator `Flow`/`ClusterFlow` and `Output`/`ClusterOutput` resources that route the collected logs (Kubernetes pods, infrastructural namespaces, ingress controllers, audit, events and systemd services) to **OpenSearch**. It is mutually exclusive with the `loki-configs` package: one excludes the other.
 
 ## Deployment
 
-You can deploy all the configurations by running the following command in the `configs` folder:
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Logging Module is installed and configured.
 
-```shell
-kustomize build | kubectl apply -f -
-```
-
-You can also deploy only a configuration subset by running some of the following commands (for example):
-
-```shell
-kustomize build kubernetes | kubectl apply -f -
-kustomize build infra | kubectl apply -f -
-kustomize build ingress-nginx | kubectl apply -f -
-kustomize build audit | kubectl apply -f -
-kustomize build events | kubectl apply -f -
-kustomize build systemd | kubectl apply -f -
-kustomize build systemd/common | kubectl apply -f -
-kustomize build systemd/etcd | kubectl apply -f -
-```
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/logging-operated/README.md
+++ b/katalog/logging-operated/README.md
@@ -2,45 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-The Logging operated package deploys the Fluentd and Fluent-bit stack via Logging operator CRDs.
-It also deploys a MinIO instance for storing all the logs rejected from the configured outputs.
+## Overview
 
-## Requirements
+The Logging Operated package deploys the Fluentd and Fluent Bit stack through the Logging Operator CRDs. Logs that the configured outputs reject are collected by an in-cluster MinIO instance with a 7-day retention, for debugging purposes.
 
-- Kubernetes >= `1.22.0`
-- Kustomize >= `v5.6.0`
-- [logging-operator][logging-operator]
-- [prometheus-operator][prometheus-operator]
-- [minio-ha](../minio-ha)
+## Upstream project
 
-## Image repository and tag
-
-- Fluentd: `ghcr.io/kube-logging/logging-operator/fluentd:6.5.1-full`
-- Fluent Bit: `ghcr.io/fluent/fluent-bit:5.0.5`
-- Config Reloader: `ghcr.io/kube-logging/logging-operator/config-reloader:6.5.1`
-
-## Configuration
-
-See the file [fluentd-fluentbit.yaml](fluentd-fluentbit.yml) in the root of the project for the stack configuration.
+This package is based on the upstream [Logging Operator][logging-operator-github].
 
 ## Deployment
 
-You can deploy Logging operated by running the following command in the root of the project:
-
-```shell
-kustomize build | kubectl apply -f - --server-side
-```
-
-## Error logs
-
-All logs with errors in being sent to their outputs are collected by two MinIO instances.
-These instances serve for debugging purposes and to understand why the collected logs are not being sent.
-These MinIO instances are configured to have a 7-day file retention.
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.operator` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[logging-operator]: https://github.com/sighupio/module-logging/tree/main/katalog/logging-operator
-[prometheus-operator]: https://github.com/sighupio/module-monitoring/tree/main/katalog/prometheus-operator
+[logging-operator-github]: https://github.com/kube-logging/logging-operator
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/logging-operator/README.md
+++ b/katalog/logging-operator/README.md
@@ -2,43 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-Logging operator for Kubernetes based on Fluentd and Fluent-bit.
+## Overview
 
-The Logging operator automates the deployment and configuration of a Kubernetes logging pipeline. The operator deploys
-and configures a Fluent-bit DaemonSet on every node to collect container and application logs from the node file system
-and a Fluentd StatefulSet that receive logs from Fluent-bit and send them to various outputs.
+The Logging Operator automates the deployment and configuration of a Kubernetes logging pipeline based on Fluentd and Fluent Bit. It deploys a Fluent Bit DaemonSet on every node to collect container and application logs from the node file system, and a Fluentd StatefulSet that receives logs from Fluent Bit and forwards them to the configured outputs.
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.22.0`
-- Kustomize >= `5.6.0`
-
-## Image repository and tag
-
-- Logging operator: `ghcr.io/kube-logging/logging-operator:6.5.1`
-- Logging operator repo: [Logging operator on GitHub][logging-operator-github]
-
-## Configuration
-
-In SIGHUP Distribution, Logging operator is deployed with the following default configuration:
-
-- Replica number: `1`
-- Resource limits are `100m` for CPU and `500Mi` for memory
+This package is based on the upstream [Logging Operator][logging-operator-github].
 
 ## Deployment
 
-You can deploy Logging operator by running the following command in the root of the project:
-
-```shell
-kustomize build | kubectl apply -f - --server-side
-```
-
-See [logging-operated](../logging-operated) for the fluentd and fluentbit stack deployment, [configs](../configs)
-for OpenSearch Flow/Clusterflow and Output/ClusterOutput configuration and [loki-configs](../loki-configs) for Loki Flow/Clusterflow and Output/ClusterOutput configuration.
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.operator` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [logging-operator-github]: https://github.com/kube-logging/logging-operator
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/loki-configs/README.md
+++ b/katalog/loki-configs/README.md
@@ -1,51 +1,16 @@
 # Logging operator configs for Loki
 
-This package is a collection of logging operator Flow/ClusterFlow and Output/ClusterOutput configs to be used together with **Loki**.
+<!-- <SD-DOCS> -->
 
-## Requirements
+## Overview
 
-- Kustomize >= `5.6.0`
-- [logging-operated](../logging-operated)
-- [logging-operator](../logging-operator)
-
-## Configuration
-
-> [!WARNING]
-> This package cannot be used together with `configs` package, one excludes the other.
-
-Configurations available (patched from the base [configs](../configs) ) :
-
-- [loki-configs](.): all the configurations.
-- [loki-configs/kubernetes](kubernetes): only the cluster wide pods logging configuration (infrastructural namespaced excluded).
-- [loki-configs/infra](infra): only the infrastructural namespaces logs
-- [loki-configs/ingress-nginx](ingress-nginx): only the nginx-ingress-controller logging configuration.
-- [loki-configs/ingress-haproxy](ingress-haproxy): only the haproxy-ingress-controller logging configuration.
-- [loki-configs/audit](audit): all the Kubernetes audit logs related configurations (with master selector and tolerations).
-- [loki-configs/events](events): all the Kubernetes events related configurations (with master selector and tolerations).
-- [loki-configs/systemd](systemd): all the systemd related configurations.
-- [loki-configs/systemd/common](systemd/common): kubelet, docker, containerd, ssh systemd service logs configuration.
-- [loki-configs/systemd/etcd](systemd/etcd): only the etcd service logs configuration (with master selector and tolerations).
+This package is a collection of Logging Operator `Flow`/`ClusterFlow` and `Output`/`ClusterOutput` resources that route the collected logs (Kubernetes pods, infrastructural namespaces, ingress controllers, audit, events and systemd services) to **Loki**. It is mutually exclusive with the `configs` package: one excludes the other.
 
 ## Deployment
 
-You can deploy all the configurations by running the following command in the root of the project:
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. See the [module documentation](../../README.md) to learn how the Logging Module is installed and configured.
 
-```shell
-kustomize build | kubectl apply -f -
-```
-
-You can also deploy only a configuration subset by running some of the following commands (for example):
-
-```shell
-kustomize build kubernetes | kubectl apply -f -
-kustomize build infra | kubectl apply -f -
-kustomize build ingress-nginx | kubectl apply -f -
-kustomize build audit | kubectl apply -f -
-kustomize build events | kubectl apply -f -
-kustomize build systemd | kubectl apply -f -
-kustomize build systemd/common | kubectl apply -f -
-kustomize build systemd/etcd | kubectl apply -f -
-```
+<!-- </SD-DOCS> -->
 
 ## License
 

--- a/katalog/loki-distributed/README.md
+++ b/katalog/loki-distributed/README.md
@@ -8,7 +8,7 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 
 ## Upstream project
 
-This package is based on the upstream [Loki][loki-gh].
+This package is based on the upstream [Loki][loki-community-gh].
 
 ## Deployment
 
@@ -16,7 +16,7 @@ This package is deployed as part of **Logging Module** when you create a cluster
 
 <!-- Links -->
 
-[loki-gh]: https://github.com/grafana/loki
+[loki-community-gh]: https://github.com/grafana-community/helm-charts
 [schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
 [schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
 [schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging

--- a/katalog/loki-distributed/README.md
+++ b/katalog/loki-distributed/README.md
@@ -2,75 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus.
-It is designed to be very cost-effective and easy to operate.
-It does not index the contents of the logs, but rather a set of labels for each log stream.
+## Overview
 
-> [!NOTE]
-> This package is named Loki Distributed because it was created using the upstream chart with the same name.
-> From version 5.0.0 of the logging module the package has been migrated to use the `Loki` chart instead as
-> upstream.
+Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. It is cost-effective and easy to operate because it does not index the contents of the logs, but rather a set of labels for each log stream. This package also provides a dynamic Loki datasource that Grafana from the Monitoring Module fetches and configures automatically.
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.24.0`
-- Kustomize >= `5.6.0`
-- [prometheus-operator from SD monitoring module][prometheus-operator]
-- [grafana from SD monitoring module][grafana] (module version `>=1.15.0`)
-- [minio-ha](../minio-ha)
-
-> Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
-> some metrics available from `loki` on prometheus
-
-## Image repository and tag
-
-- Loki image: `grafana/loki:3.7.2`
-- nginx gateway: `nginxinc/nginx-unprivileged:1.31-alpine`
-- Loki repo: [Loki on Github][loki-gh]
-- Loki documentation: [Loki at grafana.com][loki-docs]
-
-## Configuration
-
-Loki Distributed is deployed in the following configuration:
-
-- Each microservice has its own Deployment/StatefulSet
-- Each Deployment has its own HPA
-- Common resources set as:
-
-```yaml
-resources:
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 1024Mi
-```
+This package is based on the upstream [Loki][loki-gh].
 
 ## Deployment
 
-You can deploy Loki Distributed by running the following command in the root of
-the project:
-
-```shell
-kustomize build | kubectl apply -f -
-```
-
-This project also implements a dynamic Loki datasource that our Grafana from the monitoring stack automatically fetches and configures.
-To see the logs, navigate in Grafana to the [explore section][grafana-explore-doc].
-
-The nginx gateway forwards Grafana metadata (dashboard, panel and alerting rule information) to Loki via the `X-Query-Tags` header on `/loki/api/v1/` query routes, so queries can be attributed to their origin in Loki logs. This is stock upstream behavior from the chart.
-
-> Note: These instructions are only for installing Loki as a log storage solution.
-> For complete instructions, please refer to the main README of the Logging module.
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.loki` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[prometheus-operator]: https://github.com/sighupio/module-monitoring/tree/main/katalog/prometheus-operator
-[grafana]: https://github.com/sighupio/module-monitoring/tree/main/katalog/grafana
-[grafana-explore-doc]: https://grafana.com/docs/grafana/latest/explore/
 [loki-gh]: https://github.com/grafana/loki
-[loki-docs]: https://grafana.com/docs/loki/latest/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/minio-ha/README.md
+++ b/katalog/minio-ha/README.md
@@ -8,7 +8,7 @@ MinIO is a distributed object storage system. This package deploys a highly avai
 
 ## Upstream project
 
-This package is based on the upstream [MinIO][minio-gh].
+This package is based on the upstream [MinIO Chainguard][minio-chainguard-gh].
 
 ## Deployment
 
@@ -16,7 +16,7 @@ This package is deployed as part of **Logging Module** when you create a cluster
 
 <!-- Links -->
 
-[minio-gh]: https://github.com/minio/minio
+[minio-chainguard-gh]: https://github.com/chainguard-forks/minio
 [schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
 [schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
 [schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging

--- a/katalog/minio-ha/README.md
+++ b/katalog/minio-ha/README.md
@@ -2,44 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-MinIO is a popular distributed object storage system that allows organizations to deploy highly available
-and scalable storage infrastructure.
-In order to achieve high availability (HA) for MinIO, a cluster of multiple MinIO nodes must be deployed backed by their own set of PVCs.
+## Overview
 
-## Requirements
+MinIO is a distributed object storage system. This package deploys a highly available MinIO cluster of multiple nodes, each backed by its own set of PVCs, used as the in-cluster object storage backend for the logging stack.
 
-- Kubernetes >= `1.23.0`
-- Kustomize >= `5.6.0`
-- [prometheus-operator from SD monitoring module][prometheus-operator]
+## Upstream project
 
-> Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
-> some metrics available from `minio` on prometheus
-
-## Image repository and tag
-
-* MinIO image: `minio/minio` (Chainguard fork)
-* MinIO repo: [MinIO on GitHub][minio-gh]
-
-## Configuration
-
-MinIO HA is deployed in the following configuration:
-
-- Three Pod MinIO statefulset with 2 PVCs per Pod
-- Custom init Job to initialize buckets (`loki` and `errors`)  and default retention (7 days on `errors` bucket)
+This package is based on the upstream [MinIO][minio-gh].
 
 ## Deployment
 
-You can deploy minio-ha by running the following command in the root of
-the project:
-
-```shell
-kustomize build | kubectl apply -f -
-```
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.minio` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[prometheus-operator]: https://github.com/sighupio/module-monitoring/tree/main/katalog/prometheus-operator
-[minio-gh]: https://github.com/chainguard-forks/minio
+[minio-gh]: https://github.com/minio/minio
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/opensearch-dashboards/README.md
+++ b/katalog/opensearch-dashboards/README.md
@@ -2,51 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-OpenSearch Dashboards is an open-source analytics and visualization platform for OpenSearch.
-OpenSearch Dashboards lets you perform advanced data analysis and visualize data in a variety
-of charts, tables, and maps. You can use it to search, view, and interact with data
-stored in OpenSearch indices.
+## Overview
 
-## Requirements
+OpenSearch Dashboards is an open source analytics and visualization platform for OpenSearch. It lets you search, view and interact with the data stored in OpenSearch indices and visualize it in charts, tables and maps.
 
-- Kubernetes >= `1.23.0`
-- Kustomize >= `5.6.0`
+## Upstream project
 
-## Image repository and tag
-
-* OpenSearch Dashboards image: `opensearchproject/opensearch-dashboards:3.7.0`
-* OpenSearch Dashboards repo: [OpenSearch Dashboards on Github][opensearch-dashboards-github]
-* OpenSearch Dashboards documentation: [OpenSearch Dashboards at opensearch.org][opensearch-dashboards-doc]
-
-## Configuration
-
-- Replica number: `1`
-- Listens on port `5601`
-- Resource limits are `100m` for CPU and `512Mi` for memory
-- Secured by `securiyContext` *(running as non-root, removed all Linux capabilities)*
+This package is based on the upstream [OpenSearch Dashboards][opensearch-dashboards-github].
 
 ## Deployment
 
-You can deploy OpenSearch Dashboard by running the following command in the root of the project:
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.opensearch` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-```shell
-kustomize build | kubectl apply -f -
-```
+<!-- Links -->
 
-### Accessing OpenSearch Dashboards UI
-
-You can access OpenSearch Dashboards web UI by port-forwarding on port `5601`:
-
-```shell
-kubectl port-forward svc/opensearch-dashboards 5601:5601 --namespace logging
-```
-
-OpenSearch Dashboards will be available on `http://127.0.0.1:5601` from your browser.
-
-Links
-
-[opensearch-dashboards-doc]: https://opensearch.org/docs/latest/dashboards/index/
 [opensearch-dashboards-github]: https://github.com/opensearch-project/OpenSearch-Dashboards
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/opensearch-single/README.md
+++ b/katalog/opensearch-single/README.md
@@ -2,68 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-OpenSearch is an open-source distributed search and analytics engine used for
-log analytics. This package deploys a single node OpenSearch cluster on
-Kubernetes.
+## Overview
 
-> ⚠️ Please note that the OpenSearch Single variant is not intended for production use. Please use [opensearch-triple](../opensearch-triple), the high-availability version, for production.
+OpenSearch is an open source distributed search and analytics engine used for log analytics. This package deploys a single-node OpenSearch cluster on Kubernetes. The single-node variant is not intended for production use; for production deployments use the high-availability `opensearch-triple` variant.
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.24.0`
-- Kustomize >= `5.6.0`
-- [prometheus-operator][prometheus-operator]
-
-> Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
-> some metrics available from `OpenSearch` on prometheus
-
-## Image repository and tag
-
-- OpenSearch image: `opensearchproject/opensearch:3.7.0`
-- OpenSearch repo: [OpenSearch on GitHub][opensearch-gh]
-- OpenSearch documentation: [OpenSearch Homepage][opensearch-doc]
-
-## Configuration
-
-Fury distribution OpenSearch Single is deployed with the following configuration:
-
-- Single node
-- Listens on port `9200` for client connections
-- Resource limits are `2000m` for CPU and `4G` for memory
-- Requires `30Gi` storage
-- Prometheus exporter to expose OpenSearch metrics
-- Prometheus scrapes metrics every `30s`
+This package is based on the upstream [OpenSearch][opensearch-gh].
 
 ## Deployment
 
-You can deploy OpenSearch Single by running the following command in the root of
-the project:
-
-```shell
-kustomize build | kubectl apply -f -
-```
-
-## Alerts
-
-Since we are configuring a `ServiceMonitor` in this package, the following Prometheus [alerts][opensearch-rules] are already defined:
-
-| Alert                          | Description                                                          | Severity | Interval |
-|--------------------------------|----------------------------------------------------------------------|----------|:--------:|
-| OpenSearchClusterRed           | This alert fires when the health of the opensearch cluster is RED    | critical |   30m    |
-| OpenSearchYellow               | This alert fires when the health of the opensearch cluster is YELLOW | warning  |   30m    |
-| OpenSearchOfRelocationShards   | This alert fires when there are relocating shards for 30 minutes     | warning  |   30m    |
-| OpenSearchOfInitializingShards | This alert fires when there are initializing shards for 30 minutes   | warning  |   30m    |
-| OpenSearchOfUnassignedShards   | This alert fires when there are unassigned shards for 30 minutes     | warning  |   30m    |
-| OpenSearchOfPendingTasks       | This alert fires when there pending task for 30 minutes              | warning  |   30m    |
-
-> ℹ️ when using the OpenSearch single variant, the cluster will be in `YELLOW` state because of the single replica.
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.opensearch` in your `furyctl.yaml` (set `opensearch.type` to `single` or `triple`). See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[opensearch-rules]: https://awesome-prometheus-alerts.grep.to/rules.html#elasticsearch-1
 [opensearch-gh]: https://github.com/opensearch-project/OpenSearch
-[opensearch-doc]: https://opensearch.org/docs/latest
-[prometheus-operator]: https://github.com/sighupio/module-monitoring/tree/master/katalog/prometheus-operator
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/opensearch-triple/README.md
+++ b/katalog/opensearch-triple/README.md
@@ -2,56 +2,24 @@
 
 <!-- <SD-DOCS> -->
 
-OpenSearch is an open-source distributed search and analytics engine used for
-log analytics. This package deploys a three-node OpenSearch cluster on
-Kubernetes.
+## Overview
 
-`opensearch-triple` is a high-availability setup of OpenSearch, that sets
-up a 3-node cluster of `OpenSearch` for a robust and reliable setup.
+OpenSearch is an open source distributed search and analytics engine used for log analytics. This package deploys a high-availability, three-node OpenSearch cluster on Kubernetes for a robust and reliable setup, with each node scheduled on a different Kubernetes node.
 
-## Requirements
+## Upstream project
 
-- Kubernetes >= `1.24.0`
-- Kustomize >= `5.6.0`
-- [prometheus-operator][prometheus-operator]
-
-> Prometheus Operator is necessary since we configure a `ServiceMonitor` to make
-> some metrics available from `opensearch` on prometheus. Please refer,
-> [`opensearch-single](../opensearch-single/README.md#alerts) to read
-> about the available Prometheus rules.
-
-## Image repository and tag
-
-- OpenSearch image: `opensearchproject/opensearch:3.7.0`
-- OpenSearch repo: [OpenSearch on Github][opensearch-gh]
-- OpenSearch documentation: [OpenSearch Homepage][opensearch-doc]
-
-## Configuration
-
-OpenSearch Triple is deployed with the following configuration:
-
-- OpenSearch cluster with `3` nodes
-- Listens on port `9200` for client connections
-- Listens on port `9300` for node-to-node connections
-- Resource limits are `2000m` for CPU and `4G` for memory
-- Requires `30Gi` storage
-- Each OpenSearch node is running in a different Kubernetes node
-- Prometheus exporter to expose OpenSearch metrics
-- Prometheus scrapes metrics every `30s`
+This package is based on the upstream [OpenSearch][opensearch-gh].
 
 ## Deployment
 
-You can deploy OpenSearch Triple by running the following command in the root of the project:
-
-```shell
-kustomize build | kubectl apply -f -
-```
+This package is deployed as part of **Logging Module** when you create a cluster with `furyctl`. You can customize it under `spec.distribution.modules.logging.opensearch` in your `furyctl.yaml` (set `opensearch.type` to `single` or `triple`). See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
 [opensearch-gh]: https://github.com/opensearch-project/OpenSearch
-[opensearch-doc]: https://opensearch.org/docs/latest
-[prometheus-operator]: https://github.com/sighupio/module-monitoring/tree/master/katalog/prometheus-operator
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmoduleslogging
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmoduleslogging
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmoduleslogging
 
 <!-- </SD-DOCS> -->
 


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/manual-deployment flow. New `Usage` section explains the module is deployed automatically by `furyctl`, with a type-driven `### Configuration` (the `type` field selects the stack: `opensearch`, `loki`, `customOutputs` or `none`; `opensearch.type` selects `single`/`triple`) and `furyctl.yaml` examples for OpenSearch and Loki.
- **`katalog/*/README.md`**: rewritten to the shared template. Each package's customization claim was verified against the v1alpha2 schema: `opensearch-single`/`opensearch-triple`/`opensearch-dashboards` → `opensearch`, `loki-distributed` → `loki`, `minio-ha` → `minio`, `logging-operator`/`logging-operated` → `operator`; `configs` and `loki-configs` have no dedicated field (documented as not customizable, Upstream section omitted).

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left in the `SD-DOCS` blocks
- [x] Per-package customization claims and `furyctl.yaml` fields verified against the v1alpha2 schema (`type` enum, `opensearch.type`, `loki.backend`)
- [x] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.