### PR TITLE
fix: restore Loki secret name to `loki` across resources

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -524,7 +524,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - linting
+  - E2E Tests on kind clusters version 1.29.0
 clone:
   depth: 1
 trigger:
@@ -626,7 +626,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - linting
+  - E2E Tests on kind clusters version 1.30.4
 clone:
   depth: 1
 trigger:
@@ -727,7 +727,7 @@ platform:
   os: linux
   arch: amd64
 depends_on:
-  - linting
+  - E2E Tests on kind clusters version 1.31.1
 clone:
   depth: 1
 trigger:

--- a/katalog/loki-distributed/MAINTENANCE.md
+++ b/katalog/loki-distributed/MAINTENANCE.md
@@ -27,6 +27,7 @@ The script performs the following operations on top of the chart output:
 The following are handled by helm values in `MAINTENANCE.values.yaml` (no manual patching needed):
 
 - `configStorageType: Secret` — Loki config is stored as a Secret instead of a ConfigMap
+  - `configObjectName` overrides the Secret name
 - `extraEnvFrom` — injects minio credentials Secret
 - `memcached.enabled: false` — disables unused memcached ServiceAccount
 - `monitoring.serviceMonitor.enabled: true` — chart generates the ServiceMonitor natively

--- a/katalog/loki-distributed/MAINTENANCE.values.yaml
+++ b/katalog/loki-distributed/MAINTENANCE.values.yaml
@@ -41,6 +41,7 @@ deploymentMode: Distributed
 loki:
   auth_enabled: false
   configStorageType: Secret
+  configObjectName: loki
   commonConfig:
     replication_factor: 1
   storage:

--- a/katalog/loki-distributed/deploy.yaml
+++ b/katalog/loki-distributed/deploy.yaml
@@ -714,7 +714,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1009,7 +1009,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1152,7 +1152,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1296,7 +1296,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1566,7 +1566,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1708,7 +1708,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime
@@ -1850,7 +1850,7 @@ spec:
           emptyDir: {}
         - name: config
           secret:
-            secretName: loki-distributed
+            secretName: loki
         - name: runtime-config
           configMap:
             name: loki-distributed-runtime

--- a/katalog/loki-distributed/kustomization.yaml
+++ b/katalog/loki-distributed/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 secretGenerator:
-  - name: loki-distributed
+  - name: loki
     files:
       - configs/config.yaml
   - name: minio-credentials-loki


### PR DESCRIPTION
### Summary 💡

Restore Loki secret name to `loki` across resources


### Description 📝

Restore the secret name of Loki configuration to its original name (v.5.3.0)

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2207
- E2E tests executed locally with 1.35 are green 

### Future work 🔧

Not planned.
