### PR TITLE
fix: opensearch index pattern initialization

### DIFF
--- a/docs/releases/v5.4.0.md
+++ b/docs/releases/v5.4.0.md
@@ -36,6 +36,10 @@ The ingress-nginx flow regex has been updated to expect a `hostname` field in th
 
 **Compatibility:** This release requires module-ingress >= v5.0.0.
 
+## Bug Fixes and Changes 🐛
+
+[[#222](https://github.com/sighupio/module-logging/pull/222)] Fix index-patterns and ISM policy jobs labels to avoid clashing with OpenSearch and OpenSearch Dashboard relative services.
+
 ## Update Guide 🦮
 
 ### Upgrade using the distribution

--- a/katalog/opensearch-dashboards/MAINTENANCE.md
+++ b/katalog/opensearch-dashboards/MAINTENANCE.md
@@ -18,5 +18,6 @@ What was customized:
 
 - opensearch-dashboards created with secretGenerator
 - security plugin is disabled with a custom command for the container, we expect security on the ingress level or configured manually (in consequence `OPENSEARCH_HOSTS` is switched to http)
+- A CronJob (`index-patterns-cronjob`) is deployed to populate index pattern fields. Starting from OpenSearch Dashboards 3.6.0, index pattern fields are no longer automatically refreshed (see [opensearch-project/OpenSearch-Dashboards#11653](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11653)). The CronJob fetches fields via `_fields_for_wildcard` and updates each index pattern saved object with the resolved mappings.
 
 [opensearch-helm-charts]: https://github.com/opensearch-project/helm-charts/releases

--- a/katalog/opensearch-dashboards/configs/index-patterns.json
+++ b/katalog/opensearch-dashboards/configs/index-patterns.json
@@ -1,0 +1,9 @@
+[
+  "kubernetes-*",
+  "infra-*",
+  "systemd-*",
+  "events-*",
+  "audit-*",
+  "ingress-controller-*",
+  "ingress-haproxy-*"
+]

--- a/katalog/opensearch-dashboards/configs/index-patterns.ndjson
+++ b/katalog/opensearch-dashboards/configs/index-patterns.ndjson
@@ -1,7 +1,0 @@
-{"type":"index-pattern","id":"kubernetes","attributes":{"title":"kubernetes-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"infra","attributes":{"title":"infra-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"systemd","attributes":{"title":"systemd-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"events","attributes":{"title":"events-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"audit","attributes":{"title":"audit-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"ingress-controller","attributes":{"title":"ingress-controller-*","timeFieldName":"@timestamp"}}
-{"type":"index-pattern","id":"ingress-haproxy","attributes":{"title":"ingress-haproxy-*","timeFieldName":"@timestamp"}}

--- a/katalog/opensearch-dashboards/index-patterns-cronjob.yml
+++ b/katalog/opensearch-dashboards/index-patterns-cronjob.yml
@@ -13,8 +13,8 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/name: opensearch-dashboards
-            app.kubernetes.io/instance: opensearch-dashboards
+            app.kubernetes.io/name: opensearch-dashboards-patterns-job
+            app.kubernetes.io/instance: opensearch-dashboards-patterns-job
         spec:
           containers:
           - name: index-patterns
@@ -24,23 +24,38 @@ spec:
                   - ALL
               runAsNonRoot: true
               runAsUser: 1000
-            image: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
+            image: registry.sighup.io/fury/curl-jq:3.24.1
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh
             - -c
             - |
-              curl -X POST "http://opensearch-dashboards:5601/api/saved_objects/_import?overwrite=true" -H "osd-xsrf: true" --form file=@/tmp/index-patterns.ndjson
+              set -euo pipefail
+              for pattern in $(jq -r '.[]' /tmp/index-patterns.json); do
+                id="${pattern%-*}"
+                RESPONSE=$(curl -s --retry 3 --retry-delay 2 --retry-connrefused -G "http://opensearch-dashboards:5601/api/index_patterns/_fields_for_wildcard" \
+                      --data-urlencode "pattern=$pattern" \
+                      --data-urlencode "meta_fields=_source" \
+                      --data-urlencode "meta_fields=_id" \
+                      --data-urlencode "meta_fields=_type" \
+                      --data-urlencode "meta_fields=_index" \
+                      --data-urlencode "meta_fields=_score")
+              
+                BODY=$(echo "$RESPONSE" | jq -c --arg title "$pattern" '{attributes:{title:$title,timeFieldName:"@timestamp",fields:(.fields//[]|tostring)}}')
+                curl -s --retry 3 --retry-delay 2 --retry-connrefused -o /dev/null -w "$id: %{http_code}\n" \
+                  -X POST "http://opensearch-dashboards:5601/api/saved_objects/index-pattern/$id?overwrite=true" \
+                  -H "osd-xsrf: true" -H "Content-Type: application/json" -d "$BODY"
+              done
             volumeMounts:
               - name: config-volume
-                mountPath: /tmp/index-patterns.ndjson
-                subPath: index-patterns.ndjson
+                mountPath: /tmp/index-patterns.json
+                subPath: index-patterns.json
           volumes:
             - name: config-volume
               configMap:
                 name: opensearch-index-patterns
                 items:
-                  - key: index-patterns.ndjson
-                    path: index-patterns.ndjson
+                  - key: index-patterns.json
+                    path: index-patterns.json
           restartPolicy: OnFailure
   schedule: "0 * * * *"

--- a/katalog/opensearch-dashboards/kustomization.yaml
+++ b/katalog/opensearch-dashboards/kustomization.yaml
@@ -17,5 +17,5 @@ secretGenerator:
   name: opensearch-dashboards
 configMapGenerator:
 - files:
-  - configs/index-patterns.ndjson
+  - configs/index-patterns.json
   name: opensearch-index-patterns

--- a/katalog/opensearch-single/ism-policy-cronjob.yml
+++ b/katalog/opensearch-single/ism-policy-cronjob.yml
@@ -13,8 +13,8 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/name: opensearch
-            app.kubernetes.io/instance: opensearch
+            app.kubernetes.io/name: opensearch-ism-policy-job
+            app.kubernetes.io/instance: opensearch-ism-policy-job
         spec:
           containers:
             - name: policy
@@ -24,7 +24,7 @@ spec:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-              image: registry.sighup.io/fury/opensearchproject/opensearch-dashboards
+              image: registry.sighup.io/fury/curl-jq:3.24.1
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh


### PR DESCRIPTION
### Summary 💡

fix: opensearch index pattern initialization

### Description 📝

#### Problem 1
Starting from OpenSearch Dashboards 3.6.0, index pattern fields are no longer automatically refreshed (see [opensearch-project/OpenSearch-Dashboards#11653](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11653)). 
This causes a "toast" error reported in the Discover section.
The solution is to populate the index patterns fields field as "Refresh field list" button does from the UI: firstly it fetches the fields from OSD and then it updates the index pattern.

#### Problem 2
The CronJob running the job for "Problem 1" (and the CronJob for ISM policies) has the same OSD pod labels used by the service. This caused the service to incorrectly query the CronJob as well.
The solution is to change the labels for the CronJob.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2259
- Tested with a local K8S that the CronJob creates the index patterns with the fields.

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [x] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

