### PR TITLE
chore: disable opensearch dashboards experience modal

### DIFF
--- a/katalog/opensearch-dashboards/configs/opensearch_dashboards.yml
+++ b/katalog/opensearch-dashboards/configs/opensearch_dashboards.yml
@@ -12,6 +12,7 @@
 server.host: '0'
 
 explore.enabled: true
+home.disableExperienceModal: true
 
 ## If security is enabled, the following settings are required
 #opensearch.ssl.verificationMode: none


### PR DESCRIPTION
### Summary 💡

chore: disable opensearch dashboards experience modal


### Description 📝

Disable the experience modal that suggests to enable new features.
<img width="1542" height="1448" alt="image" src="https://github.com/user-attachments/assets/1e29ab44-3371-42a2-9547-1f37920837d5" />


### Breaking Changes 💔

Not detected.

### Tests performed 🧪

Tested in a local K8S that the experience modal does not appear.

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] I've updated the `docs/releases/unreleased.md` file (or equivalent)
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

