### PR TITLE
fix: remove ServiceMonitor resource and disable related configuration in OpenSearch Dashboards

### DIFF
--- a/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
+++ b/katalog/opensearch-dashboards/MAINTENANCE.values.yaml
@@ -283,18 +283,4 @@ plugins:
 # ServiceMonitor Configuration for Prometheus
 # Enabling this option will create a ServiceMonitor resource that allows Prometheus to scrape metrics from the OpenSearch service.
 serviceMonitor:
-  # Set to true to enable the ServiceMonitor resource for OpenSearch Dashboards
-  enabled: true
-
-  # HTTP path where metrics are exposed by OpenSearch Dashboards.
-  # Ensure this path is correctly set in your service.
-  path: /_prometheus/metrics
-
-  # Frequency at which Prometheus will scrape metrics.
-  # Modify as needed for your monitoring requirements.
-  interval: 10s
-
-  # additional labels to be added to the ServiceMonitor
-  # labels:
-  #  k8s.example.com/prometheus: kube-prometheus
-  labels: { }
+  enabled: false

--- a/katalog/opensearch-dashboards/deploy.yaml
+++ b/katalog/opensearch-dashboards/deploy.yaml
@@ -163,25 +163,3 @@ spec:
           - mountPath: /usr/share/opensearch-dashboards/config/opensearch_dashboards.yml
             name: opensearch-dashboards
             subPath: opensearch_dashboards.yml
----
-# Source: opensearch-dashboards/templates/serviceMonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: opensearch-dashboards-service-monitor
-  namespace: logging
-  labels:
-    helm.sh/chart: opensearch-dashboards-3.7.0
-    app.kubernetes.io/name: opensearch-dashboards
-    app.kubernetes.io/instance: opensearch-dashboards
-    app.kubernetes.io/version: "3.7.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: opensearch-dashboards
-      app.kubernetes.io/instance: opensearch-dashboards
-  endpoints:
-  - port: metrics
-    interval: 10s
-    path: /_prometheus/metrics


### PR DESCRIPTION
### Summary 💡

Remove ServiceMonitor resource and disable related configuration in OpenSearch Dashboards because it wrongly trigger a Prometheus Alert.

<img width="1405" height="311" alt="image" src="https://github.com/user-attachments/assets/590a10a6-03e1-44f0-ae64-b11e4514ae81" />


### Description 📝

The `TargetDown` alert on `opensearch-dashboards/opensearch-dashboards` fires because the `opensearch-dashboards-service-monitor` scrapes on port metrics (9601), but the Dashboards container only exposes port 5601.
The port 9601 is not declared in `containerPorts` and nothing listens on it, so every scrape gets a connection refused.

There is no Prometheus exporter plugin available for OpenSearch Dashboards (https://docs.opensearch.org/latest/install-and-configure/install-dashboards/plugins/).

The upstream chart's ServiceMonitor appears to be copied from the OpenSearch chart without adapting it to Dashboards: it defines a metrics port (9601) that only exist on the OpenSearch server with the `prometheus-exporter` plugin installed. See upstream issue https://github.com/opensearch-project/helm-charts/issues/696.

This alert was not visible before because the previous `ServiceMonitor` had a broken selector (`matchLabels: {name, instance}`) that did not match the Service labels (`app.kubernetes.io/name`, `app.kubernetes.io/instance`), so Prometheus discovered no target and the `TargetDown` rule could never fire. The chart update aligned the selector with the Service labels, allowing Prometheus to discover the target and attempt scraping which fails because the endpoint does not exist.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-logging/2272
- I tested in a local K8S that the alert is no more triggering.

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] ~I've updated the `docs/releases/unreleased.md` file (or equivalent)~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

