### PR TITLE
fix(opensearch-single): generate ISM policy payloads outside ConfigMap mount

### DIFF
--- a/katalog/opensearch-single/ism-policy-cronjob.yml
+++ b/katalog/opensearch-single/ism-policy-cronjob.yml
@@ -26,34 +26,35 @@ spec:
                 runAsUser: 1000
               image: registry.sighup.io/fury/curl-jq:3.24.1
               imagePullPolicy: IfNotPresent
+              workingDir: /tmp
               command:
                 - /bin/sh
                 - -c
                 - |
-                  cp /tmp/retention.json kubernetes-retention.json
+                  cp /config/retention.json kubernetes-retention.json
                   sed -i 's/INDEXNAME/kubernetes/g' kubernetes-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/kubernetes" -H "Content-Type: application/json" -d @./kubernetes-retention.json
-                  cp /tmp/retention.json audit-retention.json
+                  cp /config/retention.json audit-retention.json
                   sed -i 's/INDEXNAME/audit/g' audit-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/audit" -H "Content-Type: application/json" -d @./audit-retention.json
-                  cp /tmp/retention.json events-retention.json
+                  cp /config/retention.json events-retention.json
                   sed -i 's/INDEXNAME/events/g' events-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/events" -H "Content-Type: application/json" -d @./events-retention.json
-                  cp /tmp/retention.json systemd-retention.json
+                  cp /config/retention.json systemd-retention.json
                   sed -i 's/INDEXNAME/systemd/g' systemd-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/systemd" -H "Content-Type: application/json" -d @./systemd-retention.json
-                  cp /tmp/retention.json ingress-controller-retention.json
+                  cp /config/retention.json ingress-controller-retention.json
                   sed -i 's/INDEXNAME/ingress-controller/g' ingress-controller-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/ingress-controller" -H "Content-Type: application/json" -d @./ingress-controller-retention.json
-                  cp /tmp/retention.json ingress-haproxy-retention.json
+                  cp /config/retention.json ingress-haproxy-retention.json
                   sed -i 's/INDEXNAME/ingress-haproxy/g' ingress-haproxy-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/ingress-haproxy" -H "Content-Type: application/json" -d @./ingress-haproxy-retention.json
-                  cp /tmp/retention.json infra-retention.json
+                  cp /config/retention.json infra-retention.json
                   sed -i 's/INDEXNAME/infra/g' infra-retention.json
                   curl -X PUT "http://opensearch-cluster-master:9200/_plugins/_ism/policies/infra" -H "Content-Type: application/json" -d @./infra-retention.json
               volumeMounts:
                 - name: config-volume
-                  mountPath: /tmp
+                  mountPath: /config
           volumes:
             - name: config-volume
               configMap:


### PR DESCRIPTION

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterward.

Opening a PR in draft lets other team members know you're working on this change, and gives you a 
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are comfortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Fix the `ism-policy-cronjob` failure caused by writing temporary policy payload files in a non-writable location.


<!-- Write a short summary of the changes that this PR introduces and the motivations -->

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example, an error message that other users could get and search for online.
-->


<!-- If this PR is related to changes produced in other repos, like a Module or the distribution, please link them below. -->
Relates: https://github.com/sighupio/module-logging/pull/222


### Description 📝

The CronJob now mounts the ISM policy template ConfigMap under `/config` and uses `/tmp` as its working directory.

It keeps the read-only configuration input separate from the temporary JSON generated before sending each policy to OpenSearch.

<!--
Let us know what you are changing. Share anything that could provide the most context.

Feel free to add screenshots and code examples. The description could end up in the release notes to help users adopt the new feature or changes that you are introducing.

Expand on the reasoning behind any decisions you made to help reviewers understand the diff in the PR.

-->

### Breaking Changes 💔

None.

<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪

- [x] Tested the change with SD version 1.35.0 with OpenSearch. The Job completed successfully with no filesystem errors and all 7 ISM policies created.
- [x] Tested an upgrade from the previous release v5.3.0

### Future work 🔧

None.

<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->

### Self-assessment checklist 🏁

> [!IMPORTANT]
> Make sure that you completed this checklist before asking for review.
>
> PRs that do not have this checklist ready won't be reviewed.

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ]   ~~I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green

